### PR TITLE
fix(filewalker): follow symlinked dictionary directories

### DIFF
--- a/pkg/service/support/filewalker.go
+++ b/pkg/service/support/filewalker.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/op/go-logging"
 	"io/fs"
+	"os"
 	"path/filepath"
 
 	"github.com/terasum/medict/internal/utils"
@@ -44,12 +45,29 @@ func WalkDir(dirpath string) ([]*model.DirItem, error) {
 			return nil
 		}
 
-		// skip non-dir
+		// filepath.WalkDir does not follow symlinks, and a symlink's DirEntry
+		// reports ModeSymlink (not a directory) even when it points to one.
+		// Resolve symlinks so a dictionary linked into the dicts dir is scanned.
+		scanPath := path
 		if !d.IsDir() {
-			return nil
+			if d.Type()&fs.ModeSymlink == 0 {
+				// a real, non-directory file at this level: skip
+				return nil
+			}
+			resolved, rerr := filepath.EvalSymlinks(path)
+			if rerr != nil {
+				log.Errorf("resolve symlink failed, path:[%s], %s", path, rerr.Error())
+				return nil
+			}
+			fi, serr := os.Stat(resolved)
+			if serr != nil || !fi.IsDir() {
+				// broken link or link to a non-directory: skip
+				return nil
+			}
+			scanPath = resolved
 		}
 		// 遍历第二层
-		item, err := innerWalkLevel2(dirpath, path)
+		item, err := innerWalkLevel2(dirpath, scanPath)
 		if err != nil {
 			// 二层遍历失败，继续遍历下一个
 			log.Errorf("inner walker failed , path:[%s], %s", path, err.Error())


### PR DESCRIPTION
## Problem

A dictionary placed into the dicts scan directory as a **symbolic link** (e.g. `ln -s /path/to/BigDictionary "$HOME/Library/Application Support/medict/dicts/BigDictionary"`) is silently ignored and never loaded. A real directory in the same place loads fine.

## Cause

`filepath.WalkDir` does not follow symbolic links, and a symlink's `fs.DirEntry` reports `ModeSymlink` — not a directory — even when the link target *is* a directory. So in `WalkDir` (`pkg/service/support/filewalker.go`) the entry fails the `!d.IsDir()` guard and is skipped before it's ever scanned for a `.mdx`/stardict files.

## Fix

Detect symlink entries at the top level and resolve them with `filepath.EvalSymlinks`. If the resolved target is a directory, scan it as a dictionary folder. Broken links and links pointing to non-directories are skipped safely.

## Testing

Verified against a real dicts folder containing one regular dictionary directory and one symlinked dictionary directory — both are now discovered and reported as valid Mdict entries, where previously only the regular directory was found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)