### PR TITLE
fix(backserver): correct prefix check in StaticServerBaseUrl

### DIFF
--- a/pkg/backserver/back_server.go
+++ b/pkg/backserver/back_server.go
@@ -124,7 +124,7 @@ func (bs *BackServer) StaticServerBaseUrl() string {
 	listenAddr := ""
 	if bs.Ready {
 		listenAddr = bs.ListenAddr.String() + static.ContentRootUrl
-		if !strings.HasSuffix(listenAddr, "http://") {
+		if !strings.HasPrefix(listenAddr, "http://") {
 			return "http://" + listenAddr
 		}
 		return listenAddr


### PR DESCRIPTION
## 背景
修复 #679

## 修改
`pkg/backserver/back_server.go` 中 `StaticServerBaseUrl`：

```diff
-		if !strings.HasSuffix(listenAddr, "http://") {
+		if !strings.HasPrefix(listenAddr, "http://") {
```

原判断检查地址「结尾」是否为 `http://`，但 `http://` 是 URL **前缀**。该条件几乎永远为真（地址不会以 `http://` 结尾），导致函数「歪打正着」能工作，`else` 分支为死代码。改为 `HasPrefix` 以正确表达意图，并避免 `ListenAddr.String()` 返回值将来变化时反向出错。

## 验证
- `gofmt` 通过
- `go build ./pkg/backserver/` 编译通过
- 运行时行为不变（原本就总是走补 `http://` 前缀的分支）

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)