### PR TITLE
fix(apis): return correct Content-Type for woff2 fonts

### DIFF
--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -286,7 +286,7 @@ func wrapContentType(c *gin.Context, key string, data []byte) {
 	} else if strings.HasSuffix(key, ".woff") {
 		c.Data(http.StatusOK, "font/woff", data)
 	} else if strings.HasSuffix(key, ".woff2") {
-		c.Data(http.StatusOK, "font/woff", data)
+		c.Data(http.StatusOK, "font/woff2", data)
 	} else {
 		c.AbortWithStatus(http.StatusUnsupportedMediaType)
 	}


### PR DESCRIPTION
## 背景
修复 #680

## 修改
`pkg/apis/dicts_controller.go` 的 `wrapContentType` 中 `.woff2` 分支：

```diff
 } else if strings.HasSuffix(key, ".woff2") {
-	c.Data(http.StatusOK, "font/woff", data)
+	c.Data(http.StatusOK, "font/woff2", data)
 }
```

`.woff2` 资源被返回了 `font/woff`，疑似复制上一行 `.woff` 分支后遗漏修改。部分 webview 下 woff2 字体加载异常或回退到 woff。

## 验证
- `gofmt` 通过
- `go build ./pkg/apis/` 编译通过

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)