### PR TITLE
fix(backserver): avoid os.Exit in GracefulStop on shutdown error

### DIFF
--- a/pkg/backserver/back_server.go
+++ b/pkg/backserver/back_server.go
@@ -109,7 +109,7 @@ func (bs *BackServer) GracefulStop() {
 		return
 	}
 	if err := bs.Srv.Shutdown(ctx); err != nil {
-		log.Fatal("Server Shutdown:", err)
+		log.Errorf("Server Shutdown: %s", err)
 	}
 	// catching ctx.Done(). timeout of 0.4 seconds.
 	select {


### PR DESCRIPTION
## 背景
修复 #683

## 修改
`pkg/backserver/back_server.go` 的 `GracefulStop`：

```diff
 if err := bs.Srv.Shutdown(ctx); err != nil {
-	log.Fatal("Server Shutdown:", err)
+	log.Errorf("Server Shutdown: %s", err)
 }
```

`GracefulStop` 在应用 `shutdown` 生命周期（`app.go:98`）中被调用。若 `Shutdown` 返回错误，`log.Fatal` 会直接 `os.Exit(1)`，绕过 Wails 关闭流程与所有 defer。降级为 `log.Errorf`，让关闭流程走完。

## 验证
- `gofmt` 通过
- `go build ./pkg/backserver/` 编译通过（`log.Errorf` 为 go-logging 合法方法）

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)