### PR TITLE
fix: distinguish stardict index type from mdict

### DIFF
--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -38,7 +38,12 @@ func (dc *DictsController) HandleWordQueryReq(c *gin.Context) {
 	keyWordDataStartOffset := c.Query("keyword_data_start_offset")
 	keyWordDataEndOffset := c.Query("keyword_data_end_offset")
 
-	entry, err := convertKeyIndex("medict", entryId, recordStart, recordEnd, keyWord, recordBlockDataStartOffset, recordBlockDataCompressSize, recordBlockDataDeCompressSize, keyWordDataStartOffset, keyWordDataEndOffset)
+	// 根据词典实际类型决定索引类型，避免 stardict 被当作 mdict 处理（见 #678）
+	dictType := "medict"
+	if d := dc.ds.GetDictById(dictId); d != nil && d.DictType == string(model.DictTypeStarDict) {
+		dictType = "stardict"
+	}
+	entry, err := convertKeyIndex(dictType, entryId, recordStart, recordEnd, keyWord, recordBlockDataStartOffset, recordBlockDataCompressSize, recordBlockDataDeCompressSize, keyWordDataStartOffset, keyWordDataEndOffset)
 	if err != nil {
 
 		fmt.Printf("NoRoute REQ ABORT: %s (%s:%s)\n", c.Request.RequestURI, "bad param convert", err.Error())

--- a/pkg/model/dict_def.go
+++ b/pkg/model/dict_def.go
@@ -117,7 +117,7 @@ func (dict *DictionaryItem) ToPlain() *PlainDictionaryItem {
 }
 
 const IndexTypeMdict = "IndexTypeMdict"
-const IndexTypeStardict = "IndexTypeMdict"
+const IndexTypeStardict = "IndexTypeStardict"
 
 type KeyQueryIndex struct {
 	IndexType string `json:"index_type"`


### PR DESCRIPTION
## 背景
修复 #678

## 根因（两处）
1. **`pkg/model/dict_def.go:120`** — `IndexTypeStardict` 被赋值为 `"IndexTypeMdict"`，与 `IndexTypeMdict` 完全相同，两者无法区分：
   ```go
   const IndexTypeMdict    = "IndexTypeMdict"
   const IndexTypeStardict = "IndexTypeMdict"   // 与上方相同
   ```
2. **`pkg/apis/dicts_controller.go:41`** — `HandleWordQueryReq` 调用 `convertKeyIndex("medict", ...)` 硬编码，导致 `IndexType` 永远是 mdict。

## 修改
- `IndexTypeStardict` 改为独立值 `"IndexTypeStardict"`。
- `HandleWordQueryReq` 通过 `GetDictById(dictId).DictType` 动态判断词典类型后传入 `convertKeyIndex`，而非硬编码 `"medict"`。

## 关于运行时影响（重要）
经核查，`IndexType` 当前**仅作元数据**，不参与查询分发：
- `mdict.Locate` 只用 `qIndex.MdictKeyWordIndex`
- `stardict.Locate`（`startdict.go:79`）只用 `entry.KeyWord`

因此本 PR **不改变运行时查词行为**，仅修正暴露给调用方/前端的 `index_type` 值，并消除常量重复与硬编码，为将来按类型正确分发铺路。

## 验证
- `gofmt` 通过
- `go build ./pkg/apis/ ./pkg/model/` 编译通过

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)