### PR TITLE
fix(service): make DictService singleton race-free with sync.Once

### DIFF
--- a/pkg/service/dicts_service.go
+++ b/pkg/service/dicts_service.go
@@ -32,7 +32,10 @@ import (
 	"github.com/terasum/medict/pkg/service/support"
 )
 
-var singltonInstanceDictService *DictService
+var (
+	singltonInstanceDictService *DictService
+	singletonOnce               sync.Once
+)
 
 type DictService struct {
 	config   *config.Config
@@ -41,19 +44,14 @@ type DictService struct {
 }
 
 func NewDictService(config *config.Config) (*DictService, error) {
-	if singltonInstanceDictService != nil {
-		return singltonInstanceDictService, nil
-	}
-
-	ds := &DictService{
-		config:   config,
-		dicts:    make(map[string]*model.DictionaryItem),
-		dictLock: new(sync.Mutex),
-	}
-
-	singltonInstanceDictService = ds
-
-	return ds, nil
+	singletonOnce.Do(func() {
+		singltonInstanceDictService = &DictService{
+			config:   config,
+			dicts:    make(map[string]*model.DictionaryItem),
+			dictLock: new(sync.Mutex),
+		}
+	})
+	return singltonInstanceDictService, nil
 }
 
 // InitDicts initialize the dictionaries


### PR DESCRIPTION
## 背景
修复 #681

## 问题
`pkg/service/dicts_service.go` 的 `NewDictService` 用包级全局变量 `singltonInstanceDictService` 实现「先判空再赋值」单例，**无任何锁保护**：

```go
if singltonInstanceDictService != nil {   // 读
    return singltonInstanceDictService, nil
}
...
singltonInstanceDictService = ds           // 写
```

并发调用存在 TOCTOU 数据竞态，可能创建多个实例，破坏单例语义（`go test -race` 会告警）。

## 修改
用 `sync.Once` 保护构造：
```go
var (
    singltonInstanceDictService *DictService
    singletonOnce               sync.Once
)

func NewDictService(config *config.Config) (*DictService, error) {
    singletonOnce.Do(func() {
        singltonInstanceDictService = &DictService{...}
    })
    return singltonInstanceDictService, nil
}
```

## 验证
- `gofmt` 通过
- `go build ./pkg/service/` 编译通过
- 当前启动路径（`BackServer.SetUp` 单次调用）行为不变，仅在并发下变得正确

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)