### PR TITLE
fix(backserver): restrict CORS to local allowlist instead of reflecting any Origin

### DIFF
--- a/pkg/backserver/back_server_inner.go
+++ b/pkg/backserver/back_server_inner.go
@@ -67,11 +67,36 @@ func (bs *BackServer) startStaticServer(listenAddr string) {
 
 }
 
+// allowedOrigin reports whether the given Origin is permitted to make
+// cross-origin requests to the embedded resource server.
+//
+// 正式功能不依赖跨域：前端控制面走 Wails IPC，释义 HTML 及其子资源经同源
+// iframe（http://localhost:<port>）加载，本身不需要 CORS。此处仅放行本地
+// wails webview 与 loopback 调试来源，避免原实现反射任意 Origin 的安全隐患。
+func allowedOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	switch origin {
+	case "http://wails.localhost", "https://wails.localhost",
+		"wails://wails.localhost", "wails://localhost":
+		return true
+	}
+	for _, scheme := range []string{"http", "https"} {
+		for _, host := range []string{"localhost", "127.0.0.1"} {
+			if origin == scheme+"://"+host || strings.HasPrefix(origin, scheme+"://"+host+":") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func cors() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		method := c.Request.Method
 		origin := c.Request.Header.Get("Origin")
-		if origin != "" {
+		if allowedOrigin(origin) {
 			c.Writer.Header().Set("Access-Control-Allow-Origin", origin)
 			c.Header("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE,UPDATE")
 			c.Header("Access-Control-Allow-Headers", "Authorization, Content-Length, X-CSRF-Token, Token,session")


### PR DESCRIPTION
## 背景
修复 #682（安全）

## 问题
`pkg/backserver/back_server_inner.go` 的 `cors()` 中间件把请求 `Origin` **原样反射**回 `Access-Control-Allow-Origin`，并同时开启 `Allow-Credentials: true`：

```go
origin := c.Request.Header.Get("Origin")
if origin != "" {
    c.Writer.Header().Set("Access-Control-Allow-Origin", origin)  // 反射任意 Origin
    ...
    c.Header("Access-Control-Allow-Credentials", "true")
}
```

在浏览器同源策略模型下，这等同于「允许任意站点携带凭据跨域访问本服务」。该服务绑定 `localhost`，直接风险有限，但用户访问恶意网页时，该网页可向 `localhost:<port>` 发起带凭据的跨域请求读取词典内容（本地服务探测 / DNS rebinding 类攻击面）。

## 修改
不再反射任意 Origin，改为白名单 `allowedOrigin()`：
- wails webview origin（`http(s)://wails.localhost`、`wails://...` 各平台变体）
- loopback：`http(s)://localhost[:port]`、`http(s)://127.0.0.1[:port]`（保留本地调试）

## 为什么不影响正式功能
经核查前端（`frontend/src/apis/`）：
- 控制面全部走 **Wails IPC**（`Dispatch` / `ResourceServerAddr` 等），不经 HTTP 跨域；
- 释义 HTML 与其子资源（css/图片/音频）经**同源 iframe**（`http://localhost:<port>`）加载，本身不需要 CORS。

唯一跨域消费者是 `DebugResourceSearch.vue`（调试页面，本地浏览器访问，origin 为 `http://localhost:<vite-port>`），已被 loopback 白名单覆盖。

## 验证
- `gofmt` 通过
- `go build ./pkg/backserver/` 编译通过
- ⚠️ 建议维护者在各平台实测 wails webview 的实际 Origin 是否落在白名单内（不同 wails 版本/平台略有差异）；若有遗漏可补充。

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)