### PR TITLE
build: bump go directive from 1.21.0 to 1.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/terasum/medict
 
-go 1.21.0
+go 1.23.0
+
 toolchain go1.24.1
 
 require github.com/wailsapp/wails/v2 v2.6.0


### PR DESCRIPTION
## 背景
修复 #690

## 问题
`go.mod` 声明 `go 1.21.0`，但依赖 `golang.org/x/net v0.38.0` 要求 `go >= 1.23.0`。贡献者克隆后直接 `go build`/`go test` 会失败：

```
go: updates to go.mod needed; to update it:
	go mod tidy
```

必须先手动 `go mod tidy` 才能编译。

## 修改
```diff
-go 1.21.0
+go 1.23.0
+
 toolchain go1.24.1
```

将 `go` 指令提升到 `1.23.0`（`go mod tidy` 给出的**最小必要值**）。**go.sum 无任何改动**。

## 验证
- ✅ `go build ./pkg/... ./internal/...` 通过（全部库代码在 go 1.23.0 下编译）
- ✅ 修改后再跑 `go mod tidy`：go.mod / go.sum **均无变化**（即本改动已是 tidy 的期望终态，不会再次触发更新）
- 备注：`main` 包未纳入编译检查，因其 `//go:embed frontend/dist` 需要先构建前端（`pnpm build`），与本改动无关

## 说明
这是独立的构建修复，与已提交的 6 个 bug fix PR（#684–#689）无文件冲突，可独立合并。合并后本地/CI 即可直接 `go build`，无需手动 `go mod tidy`。

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)