### PR TITLE
feat(mdict): fuzzy search fallback via BK-tree

### DIFF
--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -2,11 +2,15 @@ package mdict
 
 import (
 	"errors"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/creasty/go-levenshtein"
+	"github.com/terasum/medict/internal/libs/bktree"
 	gomdict "github.com/terasum/medict/internal/libs/go-mdict"
 	"github.com/terasum/medict/pkg/model"
 	idxer "github.com/terasum/medict/pkg/service/mdict/mdict-idxer"
-	"strconv"
-	"sync"
 )
 
 type mdictHolder struct {
@@ -15,6 +19,26 @@ type mdictHolder struct {
 	dictFilePath string
 	idxer        idxer.Indexer
 	rawdict      *gomdict.Mdict
+
+	bktree     *bktree.BKTree // 模糊搜索用;BuildIndex 或首次模糊查询时构建
+	bktreeDone bool           // BK-tree 是否已构建(lazy 守卫)
+}
+
+const (
+	fuzzyTolerance = 2 // Levenshtein 容差：覆盖 1-2 字符拼写差异
+	fuzzyLimit     = 100
+)
+
+// fuzzyEntry 包装 *MdictKeyWordIndex 用于 BK-tree 模糊搜索。
+// 不复用 MdictKeyWordIndex.Distance：后者基于 utils.StrToUnicode 转义串（每个 rune 展开为 6 字符的 \uXXXX），
+// 会把 1 个 rune 的差异放大成 6 个字符的 Levenshtein 距离，使 tolerance 语义失效。
+// 这里直接在原始 KeyWord 上算字符级 Levenshtein（与 stardict 的 bkString 一致）。
+type fuzzyEntry struct {
+	*model.MdictKeyWordIndex
+}
+
+func (e *fuzzyEntry) Distance(other bktree.Entry) int {
+	return levenshtein.Distance(e.KeyWord, other.(*fuzzyEntry).KeyWord)
 }
 
 func newMdictHolder(filePath string) (*mdictHolder, error) {
@@ -195,9 +219,44 @@ func (mh *mdictHolder) BuildIndex() error {
 			log.Error(err1.Error())
 			continue
 		}
+		mh.bktreeAdd(idx)
 	}
+	mh.bktreeDone = true
 
 	err = mh.idxer.SetMeta("entries_num", strconv.FormatInt(mh.rawdict.GetKeyWordEntriesSize(), 10))
+	return nil
+}
+
+// bktreeAdd 向模糊搜索 BK-tree 添加一个词项（BuildIndex 时逐条调用）。
+func (mh *mdictHolder) bktreeAdd(e *model.MdictKeyWordIndex) {
+	if mh.bktree == nil {
+		mh.bktree = &bktree.BKTree{}
+	}
+	mh.bktree.Add(&fuzzyEntry{e})
+}
+
+// ensureBkTree 按需构建 BK-tree，兜底 .melev 缓存命中（幂等守卫跳过 BuildIndex）的场景。
+// 由 mh.lock 保护；eager 路径已在 BuildIndex 构建时本函数是 no-op。
+func (mh *mdictHolder) ensureBkTree() error {
+	mh.lock.Lock()
+	defer mh.lock.Unlock()
+	if mh.bktreeDone {
+		return nil
+	}
+	entries, err := mh.rawdict.GetKeyWordEntries()
+	if err != nil {
+		return err
+	}
+	tree := &bktree.BKTree{}
+	for _, entry := range entries {
+		idx, err1 := mh.ConvertKeyWordIndex(entry)
+		if err1 != nil {
+			continue
+		}
+		tree.Add(&fuzzyEntry{idx})
+	}
+	mh.bktree = tree
+	mh.bktreeDone = true
 	return nil
 }
 
@@ -238,12 +297,29 @@ func (mh *mdictHolder) GenerateEngineVersion() string {
 }
 
 func (mh *mdictHolder) Search(keyword string) ([]*model.MdictKeyWordIndex, error) {
-	result, err := mh.idxer.Search(keyword)
-	if err != nil {
-		return nil, err
+	// 精确前缀优先：命中直接返回
+	if result, err := mh.idxer.Search(keyword); err == nil && len(result) > 0 {
+		for idx, re := range result {
+			re.ID = idx
+		}
+		return result, nil
 	}
-	for idx, re := range result {
-		re.ID = idx
+	// 前缀为空（拼错/记不清词头）→ BK-tree 模糊兜底
+	if err := mh.ensureBkTree(); err != nil {
+		return nil, errors.New("result not found")
 	}
-	return result, nil
+	// needle 必须是 *fuzzyEntry：Distance 依赖其类型断言
+	needle := &fuzzyEntry{&model.MdictKeyWordIndex{KeyWord: keyword}}
+	raw := mh.bktree.Search(needle, fuzzyTolerance, fuzzyLimit)
+	if len(raw) == 0 {
+		return nil, errors.New("result not found")
+	}
+	sort.Slice(raw, func(i, j int) bool { return raw[i].Distance < raw[j].Distance })
+	out := make([]*model.MdictKeyWordIndex, 0, len(raw))
+	for i, r := range raw {
+		e := r.Entry.(*fuzzyEntry).MdictKeyWordIndex
+		e.ID = i
+		out = append(out, e)
+	}
+	return out, nil
 }

--- a/pkg/service/mdict/mdict_holder_fuzzy_test.go
+++ b/pkg/service/mdict/mdict_holder_fuzzy_test.go
@@ -1,0 +1,133 @@
+package mdict
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/terasum/medict/internal/libs/bktree"
+	"github.com/terasum/medict/pkg/model"
+)
+
+// fakeIdxer implements idxer.Indexer; its Search always misses, forcing the
+// holder's Search onto the fuzzy fallback path. (interface defined in
+// pkg/service/mdict/mdict-idxer/indexer.go)
+type fakeIdxer struct{}
+
+func (f *fakeIdxer) Lookup(keyword string) (*model.MdictKeyWordIndex, error) {
+	return nil, errors.New("not found")
+}
+func (f *fakeIdxer) SetMeta(key, value string) error { return nil }
+func (f *fakeIdxer) GetMeta(key string) (string, error) {
+	return "", errors.New("not found")
+}
+func (f *fakeIdxer) AddRecord(record *model.MdictKeyWordIndex) error { return nil }
+func (f *fakeIdxer) Search(keyword string) ([]*model.MdictKeyWordIndex, error) {
+	return nil, errors.New("result not found")
+}
+
+// TestFuzzyFallback verifies that a prefix miss routes through the BK-tree
+// fallback and returns the closest matches (sorted by distance).
+func TestFuzzyFallback(t *testing.T) {
+	mh := &mdictHolder{
+		lock:       &sync.Mutex{},
+		idxer:      &fakeIdxer{},
+		bktree:     &bktree.BKTree{},
+		bktreeDone: true,
+	}
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "hello", RecordLocateStartOffset: 100})
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "help", RecordLocateStartOffset: 200})
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "hallo", RecordLocateStartOffset: 300})
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "world", RecordLocateStartOffset: 400})
+
+	// "helo" is a typo of "hello" (distance 1) → fuzzy must surface it.
+	res, err := mh.Search("helo")
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, len(res), 1)
+
+	// "world" is far (> tolerance 2) → must NOT appear.
+	for _, r := range res {
+		assert.NotEqual(t, "world", r.KeyWord, "world is beyond tolerance, should not match")
+	}
+
+	// The nearest hit ("hello", distance 1) must rank first.
+	assert.Equal(t, "hello", res[0].KeyWord)
+
+	// Results carry their offsets through (frontend Locate depends on these).
+	assert.Equal(t, int64(100), res[0].RecordLocateStartOffset)
+
+	// Distances non-decreasing (ascending).
+	for i := 1; i < len(res); i++ {
+		assert.GreaterOrEqual(t, res[i].ID, res[i-1].ID)
+	}
+}
+
+// TestFuzzyRanking builds a small BK-tree directly and asserts distance ordering
+// and that an exact hit has distance 0.
+func TestFuzzyRanking(t *testing.T) {
+	tree := &bktree.BKTree{}
+	words := []struct {
+		word string
+		off  int64
+	}{
+		{"hello", 100},
+		{"hell", 200},
+		{"help", 300},
+		{"heloo", 400},
+		{"hallo", 600},
+	}
+	for _, w := range words {
+		tree.Add(&fuzzyEntry{&model.MdictKeyWordIndex{KeyWord: w.word, RecordLocateStartOffset: w.off}})
+	}
+
+	raw := tree.Search(&fuzzyEntry{&model.MdictKeyWordIndex{KeyWord: "hello"}}, fuzzyTolerance, fuzzyLimit)
+	assert.GreaterOrEqual(t, len(raw), 4)
+
+	// 必含精确匹配 hello (distance 0)，且 offset 保留（BK-tree 不保证顺序，遍历查找）
+	var exact *fuzzyEntry
+	for _, r := range raw {
+		if r.Distance == 0 {
+			exact = r.Entry.(*fuzzyEntry)
+		}
+	}
+	assert.NotNil(t, exact, "应含 distance 0 的精确匹配")
+	assert.Equal(t, "hello", exact.KeyWord)
+	assert.Equal(t, int64(100), exact.RecordLocateStartOffset, "offset 应保留")
+
+	// 所有结果 distance <= tolerance
+	for _, r := range raw {
+		assert.LessOrEqual(t, r.Distance, fuzzyTolerance)
+	}
+}
+
+// TestFuzzyTypoCorrection: a single-edit typo resolves to the target word.
+func TestFuzzyTypoCorrection(t *testing.T) {
+	mh := &mdictHolder{
+		lock:       &sync.Mutex{},
+		idxer:      &fakeIdxer{},
+		bktree:     &bktree.BKTree{},
+		bktreeDone: true,
+	}
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "hello", RecordLocateStartOffset: 100})
+
+	res, err := mh.Search("helo") // missing one 'l'
+	assert.NoError(t, err)
+	assert.Len(t, res, 1)
+	assert.Equal(t, "hello", res[0].KeyWord)
+}
+
+// TestFuzzyNoMatch: when neither prefix nor fuzzy matches, returns "result not found".
+func TestFuzzyNoMatch(t *testing.T) {
+	mh := &mdictHolder{
+		lock:       &sync.Mutex{},
+		idxer:      &fakeIdxer{},
+		bktree:     &bktree.BKTree{},
+		bktreeDone: true,
+	}
+	mh.bktreeAdd(&model.MdictKeyWordIndex{KeyWord: "hello"})
+
+	_, err := mh.Search("zzzzzzzz") // far from everything
+	assert.Error(t, err)
+}

--- a/pkg/service/mdict/mdict_holder_test.go
+++ b/pkg/service/mdict/mdict_holder_test.go
@@ -16,22 +16,19 @@ func TestMdictHolder_BuildIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := holder.Locate(&model.KeyQueryIndex{
-		IndexType: "mdx",
-		MdictKeyWordIndex: &model.MdictKeyWordIndex{
-			ID:                            0,
-			KeyWord:                       "accessorized",
-			RecordLocateStartOffset:       735416,
-			RecordLocateEndOffset:         735438,
-			IsUTF16:                       0,
-			IsRecordEncrypt:               0,
-			IsMDD:                         0,
-			RecordBlockDataStartOffset:    920434,
-			RecordBlockDataCompressSize:   8573,
-			RecordBlockDataDeCompressSize: 64463,
-			KeyWordDataStartOffset:        35367,
-			KeyWordDataEndOffset:          35389,
-		},
+	data, err := holder.Locate(&model.MdictKeyWordIndex{
+		ID:                            0,
+		KeyWord:                       "accessorized",
+		RecordLocateStartOffset:       735416,
+		RecordLocateEndOffset:         735438,
+		IsUTF16:                       0,
+		IsRecordEncrypt:               0,
+		IsMDD:                         0,
+		RecordBlockDataStartOffset:    920434,
+		RecordBlockDataCompressSize:   8573,
+		RecordBlockDataDeCompressSize: 64463,
+		KeyWordDataStartOffset:        35367,
+		KeyWordDataEndOffset:          35389,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/service/mdict/mdict_svc_test.go
+++ b/pkg/service/mdict/mdict_svc_test.go
@@ -36,7 +36,7 @@ func TestCreateSqliteIndex(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf(mdict.Name())
+	t.Logf("%s", mdict.Name())
 	err = mdict.BuildIndex()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## 背景
实现 #666。mdict 此前只有精确前缀搜索（leveldb prefix scan），拼错或记不清词头时无结果。本 PR 加入 BK-tree 模糊兜底。

## 方案：精确前缀优先 + 模糊兜底
- 有前缀结果 → 返回前缀（快、精确）
- 前缀为空（拼错/记不清）→ BK-tree Levenshtein 模糊，tolerance=2、limit=100，按距离升序

所有改动集中在 `mdictHolder`（镜像 stardict 模式），**不动 Indexer 接口、不动 mdict_svc、不动前端**。

### 关键点
- **eager 构建**：`BuildIndex` 已有完整 `GetKeyWordEntries()` slice，顺手喂 BK-tree（零额外 I/O）
- **lazy `ensureBkTree()` 兜底**：老用户已有 `.melev`、被 `entries_num` 幂等守卫跳过 BuildIndex 时，首次模糊查询按需重建（关键，否则 BK-tree 永远 nil）
- **结果自带 offset**：BK-tree 用 `ConvertKeyWordIndex` 产出的完整 offset-bearing entry 构建，前端 `Locate` + suggest 列表（shape-driven）零改动
- **不复用 `MdictKeyWordIndex.Distance`**：它在 `StrToUnicode` 转义串上算 Levenshtein（每个 rune 展开为 6 字符 `\uXXXX`），1 字母差 = distance 6，tolerance 语义失效。改用轻量 `fuzzyEntry` wrapper 直接字符级 Levenshtein（与 stardict `bkString` 一致）

## 附带修复（develop 上预存的测试编译/vet 错误，与 #666 无关，但阻碍包测试编译）
- `mdict_holder_test.go`：`Locate` 接收 `*MdictKeyWordIndex`，原测试误传 `*KeyQueryIndex`
- `mdict_svc_test.go`：`t.Logf` 需常量格式串（go vet）

## 验证（本地实跑）
- ✅ `go build ./pkg/... ./internal/...`
- ✅ `go vet ./pkg/service/mdict/...`
- ✅ `go test ./internal/libs/bktree/...`
- ✅ `go test -run TestFuzzy ./pkg/service/mdict/...` —— 4 个测试通过（fallback / ranking / typo / no-match）
- 其它 mdict 测试仍需被 gitignore 的 `testdata/*.mdx`（留给维护者本地）

## E2E（需维护者在有真实词典的环境手动）
放真实 `.mdx`（如 `internal/entry/preset/cc-cedict`）到扫描目录 → `wails dev` → 输入拼错词按 Enter → 确认 suggest 列表显示纠正词头 + 释义可渲染；重启（走 `.melev` 缓存）确认 lazy `ensureBkTree` 路径也工作。

## 备注
- CJK 语义：tolerance=2 = 最多 2 个字符差异（对中文词典合适）
- `search_tree.go` 里注释的 `simSearch` 是旧 sqlite 架构的未完成脚手架（引用已不存在的字段），无法复用，本 PR 为全新实现

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)