### PR TITLE
refactor(log): 统一包级 logger 标识 (#704)

### DIFF
--- a/app.go
+++ b/app.go
@@ -29,7 +29,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("app")
 
 // App struct
 type App struct {

--- a/internal/libs/go-mdict/mdict.go
+++ b/internal/libs/go-mdict/mdict.go
@@ -25,7 +25,7 @@ import (
 	"github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("go-mdict")
 
 type Mdict struct {
 	*MdictBase

--- a/internal/static/handler/replacer.go
+++ b/internal/static/handler/replacer.go
@@ -21,7 +21,7 @@ import (
 	"github.com/terasum/medict/pkg/model"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("static.handler")
 
 type Replacer interface {
 	Replace(dictId string, entry *model.MdictKeyWordIndex, htmlContent string) (*model.MdictKeyWordIndex, string)

--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -15,7 +15,7 @@ import (
 	"github.com/terasum/medict/pkg/service"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("apis")
 
 type DictsController struct {
 	ds *service.DictService

--- a/pkg/backserver/back_server_inner.go
+++ b/pkg/backserver/back_server_inner.go
@@ -27,7 +27,7 @@ import (
 	"github.com/terasum/medict/internal/static"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("backserver")
 
 func (bs *BackServer) startStaticServer(listenAddr string) {
 

--- a/pkg/service/log.go
+++ b/pkg/service/log.go
@@ -2,4 +2,4 @@ package service
 
 import "github.com/op/go-logging"
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("service")

--- a/pkg/service/mdict/leveldb-repo/log.go
+++ b/pkg/service/mdict/leveldb-repo/log.go
@@ -4,4 +4,4 @@ import (
 	"github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("mdict.leveldb")

--- a/pkg/service/mdict/log.go
+++ b/pkg/service/mdict/log.go
@@ -2,4 +2,4 @@ package mdict
 
 import "github.com/op/go-logging"
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("mdict")

--- a/pkg/service/mdict/mdict-idxer/log.go
+++ b/pkg/service/mdict/mdict-idxer/log.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("mdict.idxer")
 
 func logstart(method string, args interface{}) time.Time {
 	log.Infof("%s|STR|: %v", method, args)

--- a/pkg/service/support/filewalker.go
+++ b/pkg/service/support/filewalker.go
@@ -28,7 +28,7 @@ import (
 	"github.com/terasum/medict/pkg/model"
 )
 
-var log = logging.MustGetLogger("default")
+var log = logging.MustGetLogger("service.filewalker")
 
 // WalkDir 遍历第一层的所有文件夹，忽略文件
 func WalkDir(dirpath string) ([]*model.DirItem, error) {


### PR DESCRIPTION
## 背景

修复 #704。

仓库中有 10 处 `var log = logging.MustGetLogger("default")`，全部使用 `"default"` 作为 logger 标识，导致生产日志无法定位来源包。

## 改动

仅修改 logger 标识字符串，每处改为有意义的包级标识：

| 文件 | 旧标识 | 新标识 |
|---|---|---|
| `app.go` | `default` | `app` |
| `pkg/service/log.go` | `default` | `service` |
| `pkg/service/support/filewalker.go` | `default` | `service.filewalker` |
| `pkg/service/mdict/log.go` | `default` | `mdict` |
| `pkg/service/mdict/leveldb-repo/log.go` | `default` | `mdict.leveldb` |
| `pkg/service/mdict/mdict-idxer/log.go` | `default` | `mdict.idxer` |
| `pkg/backserver/back_server_inner.go` | `default` | `backserver` |
| `pkg/apis/dicts_controller.go` | `default` | `apis` |
| `internal/static/handler/replacer.go` | `default` | `static.handler` |
| `internal/libs/go-mdict/mdict.go` | `default` | `go-mdict` |

## 范围说明

- **只改 logger 标识字符串，不替换日志库**（保留 `op/go-logging`）。迁移到 `log/slog`、zap 等现代日志库属于更大的独立改动，不在本 issue 范围内。
- `app.go` 只改动 log 一行，未触碰启动逻辑（避免与 #705 冲突）。

## 验证

`GOTOOLCHAIN=go1.25.0 go build ./pkg/... ./internal/...` 通过。

Closes #704

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)