### PR TITLE
fix(apis): 修复 Wails IPC browser fallback 缺 return 导致返回 undefined

### DIFF
--- a/frontend/src/apis/apis.ts
+++ b/frontend/src/apis/apis.ts
@@ -34,7 +34,7 @@ export const StaticDictServerURL = function (): Promise<string> {
   if (window['go']) {
     return ResourceServerAddr();
   } else {
-    Promise.resolve("http://localhost:1")
+    return Promise.resolve("http://localhost:1")
   }
 };
 
@@ -42,7 +42,7 @@ export const OpenDirOrFile = function(filepath :string):Promise<void>{
   if (window['go']) {
     return OpenFinder(filepath)
   } else {
-    Promise.resolve()
+    return Promise.resolve()
   }
 }
 
@@ -50,7 +50,7 @@ export const BaseDictDirectory = function():Promise<string>{
   if (window['go']) {
     return BaseDictDir()
   } else {
-    Promise.resolve("internal error")
+    return Promise.resolve("internal error")
   }
 }
 


### PR DESCRIPTION
## 问题

`frontend/src/apis/apis.ts` 中 3 个 IPC 封装函数的 browser（无 `window['go']`）分支漏写 `return`，导致函数返回 `undefined` 而非声明的 `Promise<T>`：

- `StaticDictServerURL`（约 37 行）：`Promise.resolve("http://localhost:1")` 是语句而非 return
- `OpenDirOrFile`（约 45 行）：同
- `BaseDictDirectory`（约 53 行）：同

### 影响
浏览器 / dev 模式下调用方拿到 `undefined`，任何 `.then(url => …)` 会抛错。由于 tsconfig 未启用 strict，TypeScript 未拦截。

## 修复

三处 browser 分支补上 `return`，使函数正确返回 `Promise<T>`：

```diff
-    Promise.resolve("http://localhost:1")
+    return Promise.resolve("http://localhost:1")
```

## 验证

`cd frontend && bun run build` 通过（vite build 成功，构建产物正常输出）。

## 关于 fallback URL 的说明

`StaticDictServerURL` 的 browser 分支返回 `http://localhost:1` 作为兜底（保留原值未改动）。`http://localhost:1` 是一个无效端口（1 通常是特权端口，不会有服务监听），其作用仅是给 webview 在 IPC 不可用时一个占位 URL，避免空字符串导致的解析错误；实际生产路径都走 `window['go']` 的 `ResourceServerAddr()` 分支，因此不会真正请求该地址。如果团队认为该兜底值可能引起误解，后续可考虑改为抛出明确错误或常量。本次修复未改动它，仅补齐 return。

Closes #700

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)