### PR TITLE
fix(frontend): 修复查词历史栈后退/前进失效 (#699)

### DIFF
--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -21,7 +21,27 @@ import { defineStore } from 'pinia';
 import { InitDicts, GetAllDicts, SearchWord } from '@/apis/dicts-api';
 import { StaticDictServerURL } from '@/apis/apis';
 
-function constructQueryURL(entry) {
+/**
+ * 历史栈条目类型。统一字段命名为 `keyword`，避免历史上 `keyword` / `key_word`
+ * 混用导致的去重失效与后退/前进读不到字段的问题（issue #699）。
+ */
+export interface HistoryEntry {
+  baseurl: string;
+  dict_id: string;
+  dict: any;
+  keyword: string;
+  record_start_offset: number;
+  record_end_offset: number;
+  key_block_idx?: number;
+  entry_id: number;
+  record_block_data_start_offset: number;
+  record_block_data_compress_size: number;
+  record_block_data_decompress_size: number;
+  keyword_data_start_offset: number;
+  keyword_data_end_offset: number;
+}
+
+function constructQueryURL(entry: HistoryEntry) {
   let {
     baseurl,
     dict_id,
@@ -250,7 +270,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
 
 
 
-      const locateQuerier = {
+      const locateQuerier: HistoryEntry = {
           baseurl: this.dictApiBaseURL,
           dict_id: this.selectDict.id,
           dict: this.selectDict,
@@ -272,7 +292,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
       this._locateWord(locateQuerier);
 
     },
-    _locateWord(locateQuerier) {
+    _locateWord(locateQuerier: HistoryEntry) {
       console.log("frontend _locateWord", locateQuerier)
       let definitionURL = constructQueryURL(locateQuerier);
       this.updateMainContentURL(definitionURL);
@@ -280,17 +300,17 @@ export const useDictQueryStore = defineStore('dictQuery', {
     resetMainContent() {
       this.updateMainContent(btoa(DefaultContentTemplpate));
     },
-    pushHistory(qurier: any) {
-      if (qurier.key_word === '') {
+    pushHistory(qurier: HistoryEntry) {
+      if (!qurier.keyword || qurier.keyword === '') {
         return;
       }
       if (qurier.baseurl === '') {
         return;
       }
-      if (!this.historyStack.isEmpty() && this.historyStack.peek().key_word === qurier.key_word) {
+      if (!this.historyStack.isEmpty() && this.historyStack.peek().keyword === qurier.keyword) {
         return
       }
-      
+
       this.historyStack.push(qurier);
     },
     pushHistoryByEntryIDx(entry_idx){
@@ -299,53 +319,58 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
       const entry = this.queryPendingList[entry_idx];
 
-      const locateQuerier = {
+      const locateQuerier: HistoryEntry = {
         baseurl: this.dictApiBaseURL,
         dict_id: this.selectDict.id,
         dict: this.selectDict,
-        key_word: entry.key_word,
+        keyword: entry.keyword,
         record_start_offset: entry.record_start_offset,
         record_end_offset: entry.record_end_offset,
         key_block_idx: entry.key_block_idx,
         entry_id: entry_idx,
+        record_block_data_start_offset: entry.record_block_data_start_offset,
+        record_block_data_compress_size: entry.record_block_data_compress_size,
+        record_block_data_decompress_size: entry.record_block_data_decompress_size,
+        keyword_data_start_offset: entry.keyword_data_start_offset,
+        keyword_data_end_offset: entry.keyword_data_end_offset,
     }
 
       this.pushHistory(locateQuerier);
     },
     backHistory() {
-      let locateQuerier = this.historyStack.back();
-      if (this.inputSearchWord == locateQuerier.keyword) {
+      let locateQuerier: HistoryEntry | '' = this.historyStack.back();
+      if (!locateQuerier || this.inputSearchWord == locateQuerier.keyword) {
         return;
       }
-      this.updateInputSearchWord(locateQuerier.key_word)
+      this.updateInputSearchWord(locateQuerier.keyword)
 
       if (this.selectDict.id != locateQuerier.dict_id) {
         this.selectDict = locateQuerier.dict;
       }
 
-      SearchWord(locateQuerier.dict_id, locateQuerier.key_word ).then((res) => {
-        console.info('[store-action]{forwardHistory} success', locateQuerier.key_word, res);
+      SearchWord(locateQuerier.dict_id, locateQuerier.keyword ).then((res) => {
+        console.info('[store-action]{backHistory} success', locateQuerier.keyword, res);
         this.queryPendingList = res;
       }).catch((err) => {
-        console.info('[store-action]{forwardHistory} failed', err);
+        console.info('[store-action]{backHistory} failed', err);
       });
       this._locateWord(locateQuerier);
     },
 
     forwardHistory() {
-      let locateQuerier = this.historyStack.forward();
-      if (this.inputSearchWord == locateQuerier.key_word) {
+      let locateQuerier: HistoryEntry | '' = this.historyStack.forward();
+      if (!locateQuerier || this.inputSearchWord == locateQuerier.keyword) {
         return;
       }
 
-      this.updateInputSearchWord(locateQuerier.key_word)
+      this.updateInputSearchWord(locateQuerier.keyword)
 
       if (this.selectDict.id != locateQuerier.dict_id) {
         this.selectDict = locateQuerier.dict;
       }
 
-      SearchWord(locateQuerier.dict_id, locateQuerier.key_word ).then((res) => {
-        console.info('[store-action]{forwardHistory} success', locateQuerier.key_word, res);
+      SearchWord(locateQuerier.dict_id, locateQuerier.keyword ).then((res) => {
+        console.info('[store-action]{forwardHistory} success', locateQuerier.keyword, res);
         this.queryPendingList = res;
       }).catch((err) => {
         console.info('[store-action]{forwardHistory} failed', err);
@@ -357,10 +382,10 @@ export const useDictQueryStore = defineStore('dictQuery', {
 });
 
 class HistoryStack {
-  items: any[] = [];
+  items: HistoryEntry[] = [];
   pointer: number = -1;
 
-  push(element: any) {
+  push(element: HistoryEntry) {
     console.log('push', this.pointer, this.items);
     if (
       this.items.length > 0 &&
@@ -373,7 +398,7 @@ class HistoryStack {
     this.pointer = this.items.length - 1;
   }
 
-  back() {
+  back(): HistoryEntry | '' {
     console.log('back', this.pointer, this.items);
     if (this.pointer >= 1) {
       this.pointer -= 1;
@@ -384,7 +409,7 @@ class HistoryStack {
     return '';
   }
 
-  forward() {
+  forward(): HistoryEntry | '' {
     console.log('forward', this.pointer, this.items);
     if (this.pointer < this.items.length - 1) {
       this.pointer += 1;
@@ -403,7 +428,7 @@ class HistoryStack {
   size() {
     return this.items.length;
   }
-  peek(){
+  peek(): HistoryEntry {
     return this.items[this.items.length - 1];
   }
 }


### PR DESCRIPTION
## 根因

`frontend/src/store/dict/index.ts` 中历史栈条目字段命名前后不一致：

- `locateWord` 构造 locator 时使用 `keyword`
- `pushHistory` / `backHistory` / `forwardHistory` 读取的却是 `key_word`，而该字段在 locator 对象上**从未被赋值**，始终为 `undefined`

由此引发两个连锁问题：

1. **去重失效**：`pushHistory` 中 `this.historyStack.peek().key_word === qurier.key_word` 变成 `undefined === undefined`（恒为 `true`），首次 push 之后所有后续 push 都被静默丢弃，历史栈最多只保留 1 个有效条目。
2. **后退/前进失效**：`backHistory` / `forwardHistory` 读取 `locateQuerier.key_word`（同样为 `undefined`），后退/前进按钮（`MainFunctions.vue:81/88`）形同虚设。

此外 `backHistory` 内部还混用了 `locateQuerier.keyword` 与 `locateQuerier.key_word`，属于明显的复制粘贴遗留 bug。

## 修复

统一字段命名为 `keyword`，并新增 `HistoryEntry` 接口做类型约束，避免此类字段名漂移再次发生。

- 新增 `HistoryEntry` 接口，并为 `locateWord` / `pushHistory` / `pushHistoryByEntryIDx` / `backHistory` / `forwardHistory` / `_locateWord` / `HistoryStack` 全部加上类型标注；
- `pushHistory`：`qurier.key_word` → `qurier.keyword`，`peek().key_word` → `peek().keyword`；同时把空判断收紧为 `!qurier.keyword || qurier.keyword === ''`；
- `pushHistoryByEntryIDx`：`entry.key_word` → `entry.keyword`（与 `MainSidebar.vue:62` 中 `queryPendingList` 暴露的字段一致），并补齐 `record_block_data_*` 与 `keyword_data_*` 字段，使后退/前进到该类条目时 `_locateWord` 能正常构造查询 URL（此前这些字段缺失，会得到 `undefined` 拼接到 URL）；
- `backHistory`：统一为 `keyword`；顺带把误写为 `{forwardHistory}` 的日志标签改为 `{backHistory}`；
- `forwardHistory`：`key_word` 全部改为 `keyword`；
- `backHistory` / `forwardHistory`：当 `historyStack.back()` / `forward()` 返回空串（栈空 / 已到边界）时提前 `return`，避免对字符串取属性。

## 逻辑正确性

修复后 push / back / forward 序列行为：

- push A → push B → push C：栈为 `[A, B, C]`，pointer=2（此前 B、C 因 `undefined===undefined` 被丢弃，只剩 `[A]`）；
- back：pointer→1，定位到 B；再 back：pointer→0，定位到 A；
- forward：pointer→1，定位到 B；再 forward：pointer→2，定位到 C；
- 去重仅对相邻相同 `keyword` 生效，不再误杀。

## 验证

- `cd frontend && bun run build` 通过（vite build，14259 模块转换成功）。
- 项目当前无前端测试框架，未新增单测；以上序列为人工推理结论。

## 范围说明

仅修改 `frontend/src/store/dict/index.ts`。`utils/history-stack.ts` 为死代码，留待另一 issue 删除，本 PR 不触碰。

Closes #699

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)