### PR TITLE
chore(701): 补齐 PR 级 CI 并让 mdict 测试在缺 testdata 时跳过

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+
+jobs:
+  backend:
+    name: Backend (Go)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+
+      - name: Build
+        run: go build ./pkg/... ./internal/...
+
+      - name: Vet
+        run: go vet ./pkg/... ./internal/...
+
+      - name: Test
+        run: go test ./pkg/... ./internal/...
+
+  frontend:
+    name: Frontend (Bun)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+        working-directory: frontend
+
+      - name: Build
+        run: bun run build
+        working-directory: frontend


### PR DESCRIPTION
## 背景

Closes #701

后端测试当前无法在 CI / 干净环境运行，且仓库只有 push 到 master/develop 的打包 CI（`package-and-release.yaml`），缺少 PR 级 build/test 检查，回归全靠人眼。

## 改动

### 1. testdata 跳过策略
`pkg/service/mdict/testdata/*.mdx` 被 `.gitignore`，但 mdict 的两个测试（`mdict_holder_test.go`、`mdict_svc_test.go`）原以 `t.Fatal` 硬依赖它，导致干净环境 `go test ./pkg/service/mdict/...` 必失败、并把真正的编译/vet 问题掩盖掉。

本次在这两个依赖 testdata 的测试开头各加 `os.Stat` 守卫，文件缺失时 `t.Skip("testdata missing, skip")`：
- `TestMdictHolder_BuildIndex` 检查 `./testdata/mdx/testdict.mdx`
- `TestCreateSqliteIndex` 检查 `testdata/mdict/testdict.mdx`

效果：CI / 干净环境不再因缺 testdata 失败，而是跳过；维护者本地有 testdata 时照常运行完整测试。

### 2. PR 级 CI（新增 `.github/workflows/ci.yml`，不改 `package-and-release.yaml`）
触发：`pull_request` 到 `develop` / `master`。
- job **backend**（ubuntu-latest）：`actions/checkout` → `actions/setup-go@v5`（go 1.25.x）→ `go build ./pkg/... ./internal/...` → `go vet ./pkg/... ./internal/...` → `go test ./pkg/... ./internal/...`
- job **frontend**（ubuntu-latest）：`actions/checkout` → `oven-sh/setup-bun@v2` → `cd frontend && bun install && bun run build`

未设置 GOPROXY/goproxy.cn：GitHub Actions 网络可直连 proxy.golang.org。

## 本地验证
- `GOTOOLCHAIN=go1.25.0 go vet ./pkg/service/mdict/...` 通过
- `GOTOOLCHAIN=go1.25.0 go build ./pkg/... ./internal/...` 通过
- `go test ./pkg/service/mdict/ -run 'TestMdictHolder_BuildIndex|TestCreateSqliteIndex' -v`：两个测试在缺 testdata 时干净 SKIP（不再 FAIL）

## ⚠️ 注意：本 CI 会暴露 develop 上既有的测试/ vet 债务

这些失败**均为 develop 上预先存在、与本 PR 改动无关**，长期被「缺 testdata → 不跑测试」掩盖。本 PR 的价值正是把它们暴露出来，建议后续 issue 单独清理：

- `go vet ./pkg/... ./internal/...`（exit 1）：`internal/entry`、`internal/libs/go-mdict`、`internal/static/handler`、`internal/utils` 下的 `*_test.go` 存在多处 `t.Logf` 使用非常量格式串（printf 规则）。本 PR 不动这些文件（受限于只改 2 个测试文件 + ci.yml 的范围）。
- `pkg/service/mdict`：`TestMdict_Name` 运行期 panic —— `&mdictSvcImpl{}` 空结构体调用 `Name()` 触发 `mdict_svc.go:43` 的 `md.mdx.rawdict.Name()` nil 解引用。该测试与 testdata 无关，单独的修复（让 `Name()` 对 nil 容错，或修正测试构造）建议在后续 issue 处理。
- 另有 `pkg/service`（`TestNewByDirItem`、`TestDictService_Dicts`）、`pkg/service/stardict`、`pkg/service/support` 等既有的 setup/build 失败，同样为 develop 既有状态。

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)