### PR TITLE
fix(启动): 错误处理健壮性 (#705)

### DIFF
--- a/app.go
+++ b/app.go
@@ -38,6 +38,9 @@ type App struct {
 	errorChannel chan error
 	stopChannel  chan int
 	bs           *backserver.BackServer
+	// initErr 捕获 appInit 同步阶段的错误，由 errorChanListen 在 Wails
+	// startup() 生命周期里确定性地产出，避免向无缓冲 channel 塞值带来的时序赌博。
+	initErr error
 }
 
 // NewApp creates a new App application struct
@@ -48,12 +51,7 @@ func NewApp() *App {
 		bs:           &backserver.BackServer{Ready: false},
 	}
 
-	err := app.appInit()
-	if err != nil {
-		go func() {
-			app.errorChannel <- err
-		}()
-	}
+	app.initErr = app.appInit()
 	return app
 }
 

--- a/app_inner.go
+++ b/app_inner.go
@@ -23,6 +23,11 @@ import (
 )
 
 func (b *App) errorChanListen(ctx context.Context) {
+	// 优先处理 NewApp()/appInit() 同步阶段捕获的错误：此时 listener
+	// 已经在 Wails startup() 生命周期内运行，ctx 可用，可确定性地产出错误对话框。
+	if b.initErr != nil {
+		panicWithErrorMessageDialog(ctx, b.initErr)
+	}
 	for {
 		select {
 		case err := <-b.errorChannel:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,7 @@ func (c *Config) Write() error {
 	return c.ViperInstance.WriteConfig()
 }
 
-func (c *Config) EnsureDictsDir() string {
+func (c *Config) EnsureDictsDir() (string, error) {
 	dirPath := c.BaseDictDir
 	defer func() {
 		fmt.Printf("[medict-init]: ensure app config directory: %s\n", dirPath)
@@ -78,12 +78,12 @@ func (c *Config) EnsureDictsDir() string {
 	appdir, _ := utils.AppConfigDir()
 	dirPath = strings.ReplaceAll(dirPath, "$APPCONFDIR", appdir)
 	if utils.FileExists(dirPath) {
-		return dirPath
+		return dirPath, nil
 	}
 	// 不存在就创建
 	err := os.MkdirAll(dirPath, 0755)
 	if err == nil {
-		return dirPath
+		return dirPath, nil
 	}
 	// 依旧创建失败, 选择默认配置
 	if !strings.HasPrefix(dirPath, home) || strings.HasPrefix(dirPath, appdir) {
@@ -94,9 +94,9 @@ func (c *Config) EnsureDictsDir() string {
 	if !utils.FileExists(dirPath) {
 		err := os.MkdirAll(dirPath, 0755)
 		if err != nil {
-			panic(err)
+			return "", err
 		}
 	}
 
-	return dirPath
+	return dirPath, nil
 }

--- a/internal/entry/app_loader.go
+++ b/internal/entry/app_loader.go
@@ -73,7 +73,11 @@ func LoadApp() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	conf.BaseDictDir = conf.EnsureDictsDir()
+	baseDictDir, err := conf.EnsureDictsDir()
+	if err != nil {
+		return nil, err
+	}
+	conf.BaseDictDir = baseDictDir
 
 	err = WritePresetDictionary(conf.BaseDictDir)
 	if err != nil {

--- a/internal/entry/app_loader_test.go
+++ b/internal/entry/app_loader_test.go
@@ -39,7 +39,11 @@ func TestEnsureConfigDir(t *testing.T) {
 	t.Logf("%s", config.ConfigPath)
 	t.Logf("%s", config.BaseDictDir)
 	t.Logf("%s", config.ConfigStruct.BaseDictDir)
-	t.Logf("%s", config.EnsureDictsDir())
+	ensureDir, err := config.EnsureDictsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s", ensureDir)
 }
 
 func TestLoadApp(t *testing.T) {
@@ -48,7 +52,10 @@ func TestLoadApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir := conf.EnsureDictsDir()
+	dir, err := conf.EnsureDictsDir()
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Logf("%s", dir)
 
 	svc, err := service.NewDictService(conf)

--- a/main.go
+++ b/main.go
@@ -33,6 +33,14 @@ var assets embed.FS
 //go:embed build/appicon.png
 var icon []byte
 
+// Version 是应用版本号，CI 通过 ldflags 注入：
+//
+//	wails build -ldflags "-X main.Version=<tag>"
+//
+// 之前 main 包没有该变量，链接器静默丢弃注入，版本号始终为空。
+// 本地构建未注入时显示 "dev"。
+var Version = "dev"
+
 func main() {
 	// Create an instance of the app structure
 	app := NewApp()

--- a/pkg/service/dicts_service.go
+++ b/pkg/service/dicts_service.go
@@ -207,7 +207,10 @@ func (ds *DictService) Search(dictId string, keyword string) ([]*model.KeyQueryI
  * @return error
  */
 func (ds *DictService) walkDicts() error {
-	baseDir := ds.config.EnsureDictsDir()
+	baseDir, err := ds.config.EnsureDictsDir()
+	if err != nil {
+		return fmt.Errorf("ensure dicts dir failed: %s", err.Error())
+	}
 	items, err := support.WalkDir(baseDir)
 	if err != nil {
 		return fmt.Errorf("walk dir failed, basedir %s,  %s", baseDir, err.Error())


### PR DESCRIPTION
## 问题

启动路径的错误处理有几处脆弱点（#705）：

1. **`appInit` 错误靠 goroutine + 无缓冲 channel 传递，存在时序赌博**：`NewApp()` 在同步阶段调用 `appInit()`，失败时启动一个 goroutine 往**无缓冲** `errorChannel` 塞错，而 listener 直到 Wails `startup()` 生命周期才起。若 goroutine 调度先于 listener 就绪，发送方会阻塞，直到 listener 起来 drain；极端情况下（Wails 在 `startup` 之前就崩溃/退出）错误会被永久丢失。
2. **`EnsureDictsDir` 在 `MkdirAll` 失败时直接 `panic(err)`**（`config.go:97`），绕过了正常的错误返回路径，启动期任何目录创建失败都会让进程原地崩溃，而不是交给上层以错误对话框等形式优雅呈现。
3. **CI 的 `-X main.Version=<tag>` 注入到不存在的变量**：`package main` 没有 `Version` 变量，链接器对未知符号的 `-X` 是静默丢弃，所以版本号从未真正被注入。

## 改法

- `app.go`：`NewApp()` 不再启动 goroutine，而是把 `appInit()` 返回的 error 存入新字段 `App.initErr`；`appInit()` 仍直接返回 error，把"怎么处理"的决定权交给调用方。
- `app_inner.go`：`errorChanListen` 进入 select 循环前，先检查 `initErr` 并产出错误对话框。此时 listener 已在 Wails `startup()` 内运行、`ctx` 可用，错误被**确定性**地产出，彻底消除时序赌博。`errorChannel` 仍保留，用于将来运行期错误的传递。
- `internal/config/config.go`：`EnsureDictsDir()` 签名由 `string` 改为 `(string, error)`，去掉 `panic(err)`，改为 `return "", err`，错误正常向上冒泡。
- `internal/entry/app_loader.go` `LoadApp` 与 `pkg/service/dicts_service.go` `walkDicts` 同步处理 `EnsureDictsDir` 返回的 error。
- `internal/entry/app_loader_test.go`：两处调用同步适配新签名。
- `main.go`：新增 `var Version = "dev"`，承接 CI `wails build -ldflags "-X main.Version=<tag>"` 注入；本地未注入时显示 `dev`。

## 为什么更健壮

- **确定性优于时序**：init 错误不再依赖"goroutine 是否赶在 listener 之前/之后调度"这种无法保证的执行顺序，而是在 `startup()` 生命周期里被确定地产出，既不丢错也不会让 goroutine 永久阻塞。
- **错误冒泡优于 panic**：`EnsureDictsDir` 不再让进程原地崩溃，错误沿调用栈回到 `LoadApp` / `walkDicts`，由上层统一决定呈现方式（错误对话框 / 返回错误）。
- **修复沉默失效**：补齐 `main.Version` 后，CI 的版本号注入才真正生效。

## 备注

- `app.go` 的 `var log = logging.MustGetLogger("app")`（#708 引入的 logger 标识）保持不动，本次只动 `appInit` / `errorChannel` / `initErr` / `Version` 相关逻辑。
- `errorChannel` / `stopChannel` 及 `shutdown()` 中的 `close()` 保留不变，仅 init 错误路径改为字段直传。

## 验证

- `GOTOOLCHAIN=go1.25.0 go build ./pkg/... ./internal/...` ✅
- `GOTOOLCHAIN=go1.25.0 go vet ./internal/config/... ./internal/entry/... ./pkg/service/...` ✅
- `GOTOOLCHAIN=go1.25.0 go test ./internal/config/... ./pkg/service/...` ✅ 全 ok/skip（develop 已绿）
- `gofmt -l` 改动文件无输出 ✅
- `main` 包（依赖 `frontend/dist`）按任务约定跳过构建，仅作 `var Version = "dev"` 一行新增。

Closes #705

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)