### PR TITLE
fix(707): 前端查词主流程可靠性修复

### DIFF
--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -104,6 +104,13 @@ const DefaultContentTemplpate = `
 
 `;
 
+/**
+ * searchWord 的请求序号（last-write-wins）。
+ * 快速连续 Enter 或 iframe entry:// 跳转会触发多次 searchWord，
+ * 仅最后一次（序号最大者）的响应会真正写入 pending list，避免乱序覆盖。
+ */
+let searchWordRequestId = 0;
+
 export const useDictQueryStore = defineStore('dictQuery', {
   state: () => ({
     dictApiBaseURL: '',
@@ -147,11 +154,21 @@ export const useDictQueryStore = defineStore('dictQuery', {
         return;
       }
 
+      // last-write-wins：分配本次请求的序号，响应回来时若已过期则丢弃
+      const reqId = ++searchWordRequestId;
       SearchWord(this.selectDict.id, word).then((res) => {
+        if (reqId !== searchWordRequestId) {
+          console.info('[store-action]{searchWord} stale response, ignoring', word);
+          return;
+        }
         console.info('[store-action]{searchWord} success', word, res);
-        
+
         this.updatePendingList(res);
       }).catch((err) => {
+        if (reqId !== searchWordRequestId) {
+          console.info('[store-action]{searchWord} stale error, ignoring', word);
+          return;
+        }
         console.info('[store-action]{searchWord} failed', err);
         this.updateSetCurrentDictAsContent();
       });
@@ -209,8 +226,18 @@ export const useDictQueryStore = defineStore('dictQuery', {
     },
     setUpAPIBaseURL() {
       let count = 0;
+      const MAX_RETRIES = 30;
       let that = this;
       let inv = setInterval(function () {
+        count++;
+        if (count > MAX_RETRIES) {
+          console.error(
+            `[app init] static server url polling exceeded max retries (${MAX_RETRIES}), giving up`
+          );
+          clearInterval(inv);
+          return;
+        }
+
         let urlPromise = StaticDictServerURL();
 
         if (!urlPromise) {
@@ -228,6 +255,9 @@ export const useDictQueryStore = defineStore('dictQuery', {
             }
             // browser
             if (url === 'http://localhost:1/') {
+              console.log(
+                `[app init] static server url is placeholder, retrying times: ${count}`
+              );
               return;
             }
             if (url.startsWith('http://localhost:0/')) {

--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -92,12 +92,21 @@
       ></span>
      </div>
     </div>
-    <div id="app-content-main-iframe-wrapper"></div>
+    <div id="app-content-main-iframe-wrapper">
+      <iframe
+        ref="iframeRef"
+        class="app-content-main-iframe"
+        :src="iframeSrc"
+        frameborder="0"
+        style="border: 0;"
+        @load="onIframeLoad"
+      ></iframe>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { onMounted, onUnmounted } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useDictQueryStore } from '@/store/dict';
 import { ZoomIn16Regular, ZoomOut16Regular,ArrowClockwise20Filled, Bug16Regular, DocumentCss20Regular } from '@vicons/fluent';
 import { NIcon } from 'naive-ui';
@@ -114,65 +123,50 @@ const TOP_WIN_MSG_REFRESH = '__Medict_TOP_WIN_MSG_EVTP_REFRESH';
 const TOP_WIN_MSG_SETUP =  '__Medict_TOP_WIN_MSG__EVTY_SETUP__';
 const INNER_FRAME_MSG_ENTRY_JUMP = '__Medict_INNER_FRAME_MSG_EVTP_ENTRY_JUMP';
 
+// 声明式 iframe：通过 Vue 响应式驱动 src，避免命令式 createElement / 手动设 .src
+const iframeRef = ref<HTMLIFrameElement | null>(null);
 
-
-function cerateIframe() {
-  if (document.getElementById('app-content-main-iframe')) {
-    document.getElementById('app-content-main-iframe').remove();
+// iframe 的 src：优先使用 mainContentURL（释义查询 URL），否则用 mainContent 构造 data URL。
+// 由 Vue 响应式驱动，store 中 mainContent / mainContentURL 变化时自动更新。
+const iframeSrc = computed(() => {
+  if (dictQueryStore.mainContentURL) {
+    return dictQueryStore.mainContentURL;
   }
-  const iframe_container = document.getElementById(
-    'app-content-main-iframe-wrapper'
-  );
-  const iframe = document.createElement('iframe');
-  iframe.src = 'data:text/html;base64,' + dictQueryStore.mainContent;
-  iframe.frameBorder = '0';
-  iframe.width = '100%';
-  iframe.height = '100%';
-  iframe.id = 'app-content-main-iframe';
-  iframe.setAttribute('style', 'border: 0px;');
-  iframe_container.appendChild(iframe);
-}
+  // mainContent 为 base64，经 unicode 安全的编解码往返后构造 data URL
+  const decoded = b64DecodeUnicode(dictQueryStore.mainContent);
+  return 'data:text/html;charset=utf-8;base64,' + btoa(unescape(encodeURIComponent(decoded)));
+});
 
-function updateIframeContent(content, is_base64 = true) {
-  const iframe = document.getElementById(
-    'app-content-main-iframe'
-  ) as unknown as HTMLIFrameElement;
-  if (!iframe) {
+// iframe 加载完成后发送 setup 消息（替代原来的 1s setTimeout）
+function onIframeLoad() {
+  const win = iframeRef.value?.contentWindow;
+  if (!win) {
     return;
   }
-  if (is_base64) {
-    let encodedStr = unescape(encodeURIComponent(content));
-    let src = 'data:text/html;charset=utf-8;base64,';
-    iframe.src = src + btoa(encodedStr);
-  } else {
-    iframe.src = content;
-  }
-  setTimeout(() => {
-    iframe.contentWindow.postMessage(TOP_WIN_MSG_SETUP, '*');
-  }, 1000);
+  win.postMessage(TOP_WIN_MSG_SETUP, '*');
 }
 
-function listenInnerFrameMessage() {
-  window.onmessage = function (e) {
-    console.debug('[TOPWIN GOT INNERFRAME MSG] ', e);
-    if (!e || !e.data || !e.data.evtype) {
-      return;
-    }
+// 监听内嵌 iframe 的消息（entry:// 跳转等）。
+// 使用具名函数 + addEventListener，便于在 onUnmounted 中精确移除，避免 window.onmessage 覆盖与泄漏。
+function onInnerFrameMessage(e: MessageEvent) {
+  console.debug('[TOPWIN GOT INNERFRAME MSG] ', e);
+  if (!e || !e.data || !e.data.evtype) {
+    return;
+  }
 
-    switch (e.data.evtype) {
-      // entry:// 跳转
-      case INNER_FRAME_MSG_ENTRY_JUMP: {
-        console.log('inner frame jump to entry: ', e.data);
-        let keyWord = e.data.word;
-        keyWord = keyWord.split('#')[0];
-        dictQueryStore.updateInputSearchWord(keyWord);
-        dictQueryStore.searchWord(keyWord);
-        dictQueryStore.pushHistoryByEntryIDx(0);
+  switch (e.data.evtype) {
+    // entry:// 跳转
+    case INNER_FRAME_MSG_ENTRY_JUMP: {
+      console.log('inner frame jump to entry: ', e.data);
+      let keyWord = e.data.word;
+      keyWord = keyWord.split('#')[0];
+      dictQueryStore.updateInputSearchWord(keyWord);
+      dictQueryStore.searchWord(keyWord);
+      dictQueryStore.pushHistoryByEntryIDx(0);
 
-        break;
-      }
+      break;
     }
-  };
+  }
 }
 
 function todo() {
@@ -181,44 +175,23 @@ function todo() {
 
 // 缩小
 function zoomOut() {
-  const evtype = TOP_WIN_MSG_ZOOM_OUT;
-  const iframe = document.getElementById(
-    'app-content-main-iframe'
-  ) as unknown as HTMLIFrameElement;
-  if (!iframe) {
-    return;
-  }
-  iframe.contentWindow.postMessage(
-    { evtype: evtype, ts: new Date().getTime() },
+  iframeRef.value?.contentWindow?.postMessage(
+    { evtype: TOP_WIN_MSG_ZOOM_OUT, ts: new Date().getTime() },
     '*'
   );
 }
 
 function refresh() {
-  const iframe = document.getElementById(
-    'app-content-main-iframe'
-  ) as unknown as HTMLIFrameElement;
-  if (!iframe) {
-    return;
-  }
-  const evtype = TOP_WIN_MSG_REFRESH;
-  iframe.contentWindow.postMessage(
-    { evtype: evtype, ts: new Date().getTime() },
+  iframeRef.value?.contentWindow?.postMessage(
+    { evtype: TOP_WIN_MSG_REFRESH, ts: new Date().getTime() },
     '*'
   );
 }
 
 // 放大
 function zoomIn() {
-  const evtype = TOP_WIN_MSG_ZOOM_IN;
-  const iframe = document.getElementById(
-    'app-content-main-iframe'
-  ) as unknown as HTMLIFrameElement;
-  if (!iframe) {
-    return;
-  }
-  iframe.contentWindow.postMessage(
-    { evtype: evtype, ts: new Date().getTime() },
+  iframeRef.value?.contentWindow?.postMessage(
+    { evtype: TOP_WIN_MSG_ZOOM_IN, ts: new Date().getTime() },
     '*'
   );
 }
@@ -234,50 +207,15 @@ function showInspector() {
   }
 }
 
-
-let storeChangeUnscribe = null;
-function listenContentUpdate() {
-  storeChangeUnscribe = dictQueryStore.$onAction(({name, store, after}) => {
-      after((result: any) => {
-        switch (name) {
-          case 'updateMainContent': {
-            const content = b64DecodeUnicode(store.mainContent);
-            updateIframeContent(content, true);
-            break;
-          }
-          case 'updateMainContentURL': {
-            if (store.mainContentURL === '') {
-              const content = b64DecodeUnicode(store.mainContent);
-              updateIframeContent(content, true);
-            }
-
-            updateIframeContent(store.mainContentURL, false);
-            break;
-          }
-        }
-      });
-    }
-  );
-}
-
 onMounted(() => {
-  cerateIframe();
-  if (storeChangeUnscribe) {
-    storeChangeUnscribe();
-    storeChangeUnscribe = null;
-  }
-  listenContentUpdate();
-  listenInnerFrameMessage();
+  window.addEventListener('message', onInnerFrameMessage);
   setTimeout(function () {
     dictQueryStore.setUpAPIBaseURL();
   }, 1000);
 });
 
-onUnmounted(()=>{
-  if(storeChangeUnscribe) {
-    storeChangeUnscribe();
-    storeChangeUnscribe = null;
-  }
+onUnmounted(() => {
+  window.removeEventListener('message', onInnerFrameMessage);
 })
 
 ///----------------------------

--- a/frontend/src/view/main/MainSidebar.vue
+++ b/frontend/src/view/main/MainSidebar.vue
@@ -69,7 +69,7 @@
 import AppSidebar from "@/components/layout/AppSidebar.vue";
 
 import { useDictQueryStore } from '@/store/dict';
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
 const dictQueryStore = useDictQueryStore();
 const selected_id = ref('0');
 
@@ -78,29 +78,50 @@ function selectItem(entry_id) {
   dictQueryStore.locateWord(entry_id);
 }
 
+// 焦点守卫：当用户正在输入框 / 文本域 / contenteditable 中输入时，不劫持方向键
+function isTextInputActive() {
+  const ae = document.activeElement;
+  if (!ae) {
+    return false;
+  }
+  const tag = ae.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || ae.isContentEditable;
+}
 
-onMounted(()=>{
-  // const list = document.getElementById('word-pending-list');
-  document.addEventListener('keydown', (e) => {
-     if (e.key == 'ArrowUp') {
-      if (selected_id.value == '0') {
-        selected_id.value = dictQueryStore.queryPendingList.length - 1;
-      } else {
-        selected_id.value = parseInt(selected_id.value) - 1;
-      }
-      dictQueryStore.locateWord(selected_id.value);
-    } else if (e.key == 'ArrowDown') {
-      if (selected_id.value == dictQueryStore.queryPendingList.length - 1) {
-        selected_id.value = '0';
-      } else {
-        selected_id.value = parseInt(selected_id.value) + 1;
-      }
-      dictQueryStore.locateWord(selected_id.value);
+function onKeyDown(e) {
+  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+    return;
+  }
+  if (isTextInputActive()) {
+    return;
+  }
+  const len = dictQueryStore.queryPendingList.length;
+  if (!len || len <= 0) {
+    return;
+  }
+  if (e.key == 'ArrowUp') {
+    if (selected_id.value == '0') {
+      selected_id.value = len - 1;
+    } else {
+      selected_id.value = parseInt(selected_id.value) - 1;
     }
+    dictQueryStore.locateWord(selected_id.value);
+  } else if (e.key == 'ArrowDown') {
+    if (selected_id.value == len - 1) {
+      selected_id.value = '0';
+    } else {
+      selected_id.value = parseInt(selected_id.value) + 1;
+    }
+    dictQueryStore.locateWord(selected_id.value);
+  }
+}
 
-  });
-  
+onMounted(() => {
+  document.addEventListener('keydown', onKeyDown);
+});
 
-})
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeyDown);
+});
 
 </script>


### PR DESCRIPTION
## 背景

Closes #707

前端查词主流程存在几处可靠性问题：命令式操纵 iframe 绕过 Vue 响应式、全局键盘监听泄漏、searchWord 无竞态防护、API 基址轮询器逻辑缺陷。本 PR 逐项修复。

## 改动

### 1. `frontend/src/view/main/MainContentFrame.vue` — 声明式 iframe
- 删除命令式 `cerateIframe`（`document.createElement` + 设 `.src` + `appendChild`）与 `updateIframeContent`（手动设 `.src` + 1s `setTimeout` 发 setup 消息）。
- 改为声明式 `<iframe ref="iframeRef" :src="iframeSrc" @load="onIframeLoad">`，由 Vue 响应式驱动：
  - `iframeSrc` 为 `computed`：`mainContentURL` 非空时用它（释义查询 URL），否则用 `mainContent`（base64）经 unicode 安全编解码往返构造 data URL。
  - `@load="onIframeLoad"` 在 iframe 加载完成后发送 setup 消息，替代原来的固定 1s `setTimeout`（更准确、无竞态）。
- 删除 `$onAction` 订阅（`listenContentUpdate` / `storeChangeUnscribe`），computed 自动响应 store 变化。
- `window.onmessage = ...` 改为具名函数 `onInnerFrameMessage` + `addEventListener('message', ...)`，并在 `onUnmounted` 中 `removeEventListener`，避免覆盖与泄漏（仍处理 `INNER_FRAME_MSG_ENTRY_JUMP` 的 entry:// 跳转）。
- `zoomIn`/`zoomOut`/`refresh` 改用 `iframeRef.value?.contentWindow?.postMessage(...)`，不再 `getElementById`。

### 2. `frontend/src/view/main/MainSidebar.vue` — 键盘监听清理 + 焦点守卫
- 原 `onMounted` 内以匿名箭头函数注册 `document keydown`，`onUnmounted` 不移除 → 路由切换累积监听。现抽出具名函数 `onKeyDown`，在 `onUnmounted` 调用 `removeEventListener` 清理。
- 新增焦点守卫 `isTextInputActive()`：当 `document.activeElement` 为 `INPUT`/`TEXTAREA`/`contenteditable` 时（如搜索框 n-input）不劫持 ArrowUp/ArrowDown，避免影响用户输入。
- 顺手加了空列表保护（`queryPendingList` 为空时不越界）。

### 3. `frontend/src/store/dict/index.ts` — searchWord 竞态 + 轮询器修复
> 注：历史栈字段（`keyword` + `HistoryEntry`）保持 #711 的统一结果，未改动。

- **searchWord 加请求 token（last-write-wins）**：新增模块级 `searchWordRequestId`，每次调用自增并捕获本次序号；响应回来时若序号已过期则丢弃（success 与 error 均守卫），避免快速 Enter 或 iframe entry-jump 的乱序覆盖。
- **`setUpAPIBaseURL` 轮询器修复**：
  - `count` 每轮递增（原来声明后从不自增，日志永远显示「重试 0」）。
  - 新增最大重试上限 `MAX_RETRIES = 30`，超限后 `clearInterval` 放弃，避免无限轮询。
  - placeholder（`http://localhost:1/`）分支补上日志；各 fallback 分支语义清晰（重试直到上限）。

## 验证

- `cd frontend && ~/.bun/bin/bun install`（274 packages）
- `cd frontend && ~/.bun/bin/bun run build` 通过（`✓ built in 2m 49s`，14209 modules transformed；chunk 体积告警为既有现象，与本次改动无关）。
- 全仓 grep 确认 `MainContentFrame.vue` 中 `getElementById`/`cerateIframe`/`updateIframeContent`/`window.onmessage`/`storeChangeUnscribe` 已无残留（仅注释中提及）。

Co-Authored-By: Claude <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)