### PR TITLE
fix(718): 修复 entry:// 词条链接触发系统级 URL 错误弹窗

### DIFF
--- a/internal/static/handler/content_pipeline.go
+++ b/internal/static/handler/content_pipeline.go
@@ -72,7 +72,7 @@ func WrapDesc(dictid, title, desc string) string {
 
 func WrapContent(dict *model.PlainDictionaryItem, keyEntry *model.MdictKeyWordIndex, definition string) ([]byte, error) {
 	content := handleContent(dict, keyEntry, definition)
-	return []byte(fmt.Sprintf(tmpl.WordDefinitionTempl, dict.Name, dict.ID, dict.Name, dict.ID, content)), nil
+	return []byte(fmt.Sprintf(tmpl.WordDefinitionTempl, dict.Name, dict.ID, dict.Name, dict.ID, dict.ID, content)), nil
 }
 
 func WrapResource(dictId string, keyWord string, resource []byte) ([]byte, error) {

--- a/internal/static/handler/replacer_entry.go
+++ b/internal/static/handler/replacer_entry.go
@@ -30,11 +30,22 @@ var ENTRY_REG *regexp.Regexp
 
 func init() {
 	var err error
-	ENTRY_REG, err = regexp.Compile(`href=\"entry://([\w#_ -]+)\"`)
+	// Capture the entry word as "anything up to the closing quote". The old
+	// whitelist [\w#_ -] skipped entry IDs containing '=', '.', '/', ':', ...
+	// (e.g. entry://topic_transport-by-water_level=c1, issue #718): the href
+	// stayed a raw entry:// link, the webview passed the unknown scheme to the
+	// OS, and the user saw "There is no application set to open the URL
+	// entry://...".
+	ENTRY_REG, err = regexp.Compile(`href=\"entry://([^\"]+)\"`)
 	if err != nil {
 		panic(err)
 	}
 }
+
+// entryWordEscaper makes a captured entry word safe to splice into the
+// single-quoted JS string literal emitted below. Backslash and single quote
+// are the only characters that can break out of that literal.
+var entryWordEscaper = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
 
 type ReplacerEntry struct {
 }
@@ -51,13 +62,11 @@ func (r *ReplacerEntry) Replace(dictId string, entry *model.MdictKeyWordIndex, h
 		if len(matched) != 2 {
 			continue
 		}
-		oldStr := matched[0]
-		oldWord := strings.TrimRight(matched[0], "\"")
-		oldWord = strings.TrimPrefix(oldWord, "href=\"entry://")
+		oldStr := matched[0]  // href="entry://<word>"
+		oldWord := matched[1] // <word>
+		escapedWord := entryWordEscaper.Replace(oldWord)
 
-		newStr := fmt.Sprintf("href=\"javascript:__medict_entry_jump('%s', '%s');\"", oldWord, dictId)
-		fmt.Printf("old %s => new %s\n", oldStr, newStr)
-
+		newStr := fmt.Sprintf("href=\"javascript:__medict_entry_jump('%s', '%s');\"", escapedWord, dictId)
 		newhtml = strings.ReplaceAll(newhtml, oldStr, newStr)
 	}
 

--- a/internal/static/handler/replacer_entry_test.go
+++ b/internal/static/handler/replacer_entry_test.go
@@ -17,6 +17,7 @@
 package handler
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -24,4 +25,35 @@ func TestReplacerEntry_Replace(t *testing.T) {
 	entry := &ReplacerEntry{}
 	_, html := entry.Replace("X182310003", nil, TESTENTRYHTML)
 	t.Logf("%s", html)
+}
+
+// Regression for #718: entry:// IDs may contain '=' and other non-word chars
+// ('.', '/', ':', ...). The old whitelist [\w#_ -] did not match them, so the
+// raw entry:// href survived into the page and the webview handed it to the OS.
+func TestReplacerEntry_HandlesNonWordCharsInEntryURL(t *testing.T) {
+	entry := &ReplacerEntry{}
+	in := `<a href="entry://topic_transport-by-water_level=c1">x</a>`
+	_, out := entry.Replace("dict123", nil, in)
+
+	if strings.Contains(out, "entry://") {
+		t.Fatalf("raw entry:// href must be rewritten away, got: %s", out)
+	}
+	want := `__medict_entry_jump('topic_transport-by-water_level=c1', 'dict123')`
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected rewritten jump call containing %q, got: %s", want, out)
+	}
+}
+
+// A captured entry word is spliced into a single-quoted JS literal, so quotes
+// and backslashes must be escaped or they break/inject into the href.
+func TestReplacerEntry_EscapesWordForJSLiteral(t *testing.T) {
+	entry := &ReplacerEntry{}
+	_, out := entry.Replace("d1", nil, `<a href="entry://it's">x</a>`)
+
+	if strings.Contains(out, `('it's`) {
+		t.Fatalf("single quote in entry word must be escaped, got: %s", out)
+	}
+	if !strings.Contains(out, `it\'s`) {
+		t.Fatalf("expected escaped quote in output, got: %s", out)
+	}
 }

--- a/internal/static/tmpl/dict_def_templ.go
+++ b/internal/static/tmpl/dict_def_templ.go
@@ -42,6 +42,7 @@ function __medict_play_sound(mp3url) {
 // top-inner frame communication
 //**************************
 var __TOPFRAME_SECURE_ORIGIN__ = "*";
+var __MEDICT_DICT_ID__ = "%s";
 function __medict_entry_jump(word, dict_id) {
 	console.log("[inner frame] jump entry => ", word, dict_id);
 	if (window.top){
@@ -77,6 +78,24 @@ function __medict_entry_jump(word, dict_id) {
 		}
     })
 }())
+
+// Defense-in-depth (#718): intercept any entry:// link the backend replacer did
+// NOT rewrite to javascript:__medict_entry_jump(...) (e.g. hrefs that use single
+// quotes, or entry IDs the regex still misses). Without this guard the webview
+// hands the unknown entry:// scheme to the OS, producing
+// "There is no application set to open the URL entry://...".
+!(function(){
+	var ENTRY_PREFIX = "entry://";
+	document.addEventListener("click", function(e) {
+		var t = e.target;
+		var a = t && t.closest ? t.closest("a") : null;
+		if (!a) return;
+		var href = a.getAttribute("href") || "";
+		if (href.indexOf(ENTRY_PREFIX) !== 0) return;
+		e.preventDefault();
+		__medict_entry_jump(href.slice(ENTRY_PREFIX.length), __MEDICT_DICT_ID__);
+	});
+}());
 
 </script>
 </head>


### PR DESCRIPTION
## 问题

Closes #718

点击词典释义里的 `entry://` 词条链接（如 `entry://topic_transport-by-water_level=c1`）时，弹出系统级错误：

> There is no application set to open the URL `entry://topic_transport-by-water_level=c1`

## 根因

`internal/static/handler/replacer_entry.go` 的正则用白名单字符类匹配词条 ID：

```go
regexp.Compile(`href=\"entry://([\w#_ -]+)\"`)
```

字符类 `[\w#_ -]` **不含 `=`**，而该词条 ID 含 `=` → 正则匹配失败 → `href="entry://..."` 原样保留 → iframe 点击未知 scheme `entry://` → webview（WKWebView/WebView2）把未知 scheme 交给 OS → OS 找不到处理程序，弹错误对话框。

测试夹具 `TESTENTRYHTML` 里恰好只有 `topic_healthcare_level_c1` 这类纯 `[\w_\-]` 链接，所以一直没被测到。

## 修复（双层）

**① 后端正则放宽 + 转义**（`replacer_entry.go`）
- 正则 `[\w#_ -]+` → `[^"]+`，覆盖 `= . / :` 等任意字符
- 改用捕获组 `matched[1]` 取词，替掉脆弱的 `TrimRight/TrimPrefix`
- 新增 `entryWordEscaper` 对 `\`、`'` 转义，防止词条词破坏/注入生成的 `javascript:` 字符串字面量
- 删除每次替换都打印的 `fmt.Printf` 调试残留

**② 前端模板兜底拦截**（`dict_def_templ.go`）
- 释义 iframe 模板注入 document 级 `click` 拦截器：任何未被后端改写、仍以 `entry://` 开头的 href，`preventDefault()` 后走 `__medict_entry_jump`，保证漏网的 `entry://` 链接永远不会再漏到 OS（连单引号 href 这类后端正则本就漏的情况也能兜住）
- 模板加 `var __MEDICT_DICT_ID__ = "%s"`，`content_pipeline.go` 的 `WrapContent` 多传一个 `dict.ID` 实参（6 个 `%s` ↔ 6 个实参，已核对）

## 验证

- `TestReplacerEntry_Replace`（旧 fixture）✅ 仍正确改写、无 `entry://` 残留
- 新增 `TestReplacerEntry_HandlesNonWordCharsInEntryURL` ✅ 复现 issue 的 `=c1` 用例
- 新增 `TestReplacerEntry_EscapesWordForJSLiteral` ✅ 引号转义
- `go vet ./internal/static/...` 干净；全量 `go build ./...` + `go test ./internal/...` 全绿

## 改动文件

```
internal/static/handler/replacer_entry.go        # 正则放宽 + 转义 + 去 Printf
internal/static/handler/replacer_entry_test.go   # 2 个回归测试
internal/static/tmpl/dict_def_templ.go           # click 拦截器 + __MEDICT_DICT_ID__
internal/static/handler/content_pipeline.go      # WrapContent 多传 dict.ID
```

## 附带发现（未在本 PR 范围）

词典描述用的 `DictDescTempl`（dict_desc_templ.go）是裸 HTML，连 `__medict_entry_jump` 都没定义——若某词典描述含 `entry://` 链接，点击会 ReferenceError。建议单独开 issue 跟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)