### PR TITLE
chore(release): 重写发布管线为 tag 触发 + 补 v3.1.0 CHANGELOG

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -1,182 +1,151 @@
-name: Build Medict Tasks
+name: Release
+
+# Releasing: push a `v*` tag (e.g. `git tag v3.1.0 && git push --tags`) and the
+# three-platform build + GitHub Release runs automatically. To validate without
+# publishing, use "Run workflow" in the Actions UI (workflow_dispatch) — it
+# produces a DRAFT release tagged with whatever label you enter, which you can
+# inspect and delete.
 on:
   push:
-#    tags:
-#      - v*
-    branches:
-      - master
-      - develop
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version label for artifacts (e.g. v3.1.0-rc1). A DRAFT release is created — no published release, safe to delete.'
+        required: true
+        default: 'v0.0.0-dryrun'
+
+# softprops/action-gh-release needs to create the release + tag.
+permissions:
+  contents: write
+
+# On a tag push GITHUB_REF_NAME is the tag (e.g. v3.1.0). On workflow_dispatch
+# we use the input. Either way this is both the artifact label and the tag.
+env:
+  VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
 
 jobs:
-  package:
+  build:
+    name: Build (${{ matrix.name }})
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.21.x]
-        platform: [macos-latest, ubuntu-20.04, windows-2019]
-    runs-on: ${{ matrix.platform }}
+        include:
+          - { runner: macos-14,      target: darwin/universal, name: Darwin_universal }
+          - { runner: ubuntu-22.04,  target: linux/amd64,      name: Linux_x86_64 }
+          - { runner: windows-latest, target: windows/amd64,   name: Windows_x86_64 }
+    runs-on: ${{ matrix.runner }}
     steps:
-      - name: Get version tag (unix)
-        if: matrix.platform != 'windows-2019'
-        id: version
-        run: echo "::set-output name=tag::v-3.0.1-alpha-${GITHUB_SHA:0:6}"
+      - name: Checkout
+        uses: actions/checkout@v4
 
-#      - name: Get version tag (windows)
-#        if: matrix.platform == 'windows-2019'
-#        id: versionw
-#        run: |
-#          echo "::set-output name=tag::v3.0.1-alpha-temp"
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
 
-      - name: Setup bun
+      - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Chechout
-        uses: actions/checkout@v2
-
-      - name: Install Wails
+      - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
-      # darwin
-      - name: Build for darwin
-        if: matrix.platform == 'macos-latest'
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
         run: |
-          wails build -f -ldflags "-X main.Version=${{ steps.version.outputs.tag }}"
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
-      - name: Create darwin disk image
-        if: matrix.platform == 'macos-latest'
+      # main.Version is the app version var (main.go), injected via ldflags on
+      # every platform. Defaults to "dev" when unset.
+      - name: Build (Wails)
+        shell: bash
+        run: wails build -platform ${{ matrix.target }} -ldflags "-X main.Version=${{ env.VERSION }}"
+
+      # ---- macOS: always ship a zipped .app; dmg is best-effort ----
+      - name: Package macOS (.app zip)
+        if: runner.os == 'macOS'
+        run: |
+          cd build/bin
+          ditto -c -k --keepParent Medict.app "../Medict_${{ env.VERSION }}_${{ matrix.name }}.zip"
+
+      - name: Package macOS (.dmg)
+        if: runner.os == 'macOS'
+        continue-on-error: true
         run: |
           brew install create-dmg
-          ls -lh $PWD && ls -lh $PWD/build
-          create-dmg --volname "Medict" --volicon "build/assets/darwin/dmg_icon.icns" --background "build/assets/darwin/dmg_bg.png" --window-size 512 360 --icon-size 100 --icon "Medict.app" 100 185  --hide-extension "Medict.app" --app-drop-link 388 185 "Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg" "build/bin"
+          create-dmg \
+            --volname "Medict" \
+            --volicon "build/assets/darwin/dmg_icon.icns" \
+            --background "build/assets/darwin/dmg_bg.png" \
+            --window-size 512 360 --icon-size 100 \
+            --icon "Medict.app" 100 185 \
+            --hide-extension "Medict.app" \
+            --app-drop-link 388 185 \
+            "Medict_${{ env.VERSION }}_${{ matrix.name }}.dmg" \
+            "build/bin"
 
+      # ---- Linux: tar.gz ----
+      - name: Package Linux
+        if: runner.os == 'Linux'
+        run: tar -C build/bin -czf "Medict_${{ env.VERSION }}_${{ matrix.name }}.tar.gz" Medict
 
-      - name: Upload darwin disk image
-        if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v2
+      # ---- Windows: zip ----
+      - name: Package Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path build/bin/Medict.exe -DestinationPath "Medict_${{ env.VERSION }}_${{ matrix.name }}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
         with:
-          name: Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg
-          path: Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg
-
-      # linux
-      - name: Build for linux
-        if: matrix.platform == 'ubuntu-20.04'
-        run: |
-          sudo apt update && sudo apt install -y libgtk-3-dev libwebkit2gtk-4.0-dev
-          wails build -f -ldflags "-X main.Version=${{ steps.version.outputs.tag }}"
-          ls -lh $PWD && ls -lh $PWD/build
-          tar -C build/bin -zcvf Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz Medict
-
-      - name: Upload linux tar.gz
-        if: matrix.platform == 'ubuntu-20.04'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz
-          path: Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz
-
-      # windows
-      - name: Build for windows
-        if: matrix.platform == 'windows-2019'
-        run: |
-          New-Item -ItemType directory -Path "$HOME\.wails" -Force
-          Copy-Item -Path "$PWD\wails.json" -Destination "$HOME\.wails\wails.json"
-          choco install mingw
-          wails build -f -ldflags "-X medict/internal/app.semver=unknown"
-          Compress-Archive -Path "$PWD\build\bin\medict.exe" -DestinationPath "$PWD\Medict_Windows_x86_64.zip"
-
-      - name: Upload windows zip
-        if: matrix.platform == 'windows-2019'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Medict_Windows_x86_64.zip
-          path: Medict_Windows_x86_64.zip
-
-
-      # - name: Create linux app image
-      #   if: matrix.platform == 'ubuntu-16.04'
-      #   run: |
-      #     wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-      #     chmod +x linuxdeploy-x86_64.AppImage
-      #     mogrify -resize 512x512 appicon.png
-      #     ./linuxdeploy*.AppImage --appdir AppDir --executable build/wombat --desktop-file AppImage.desktop --icon-file appicon.png --output appimage
-      #     mv Wombat*.AppImage Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage
-
-      # - name: Upload linux app image
-      #   if: matrix.platform == 'ubuntu-16.04'
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage
-      #     path: Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage
-
-
+          name: Medict_${{ env.VERSION }}_${{ matrix.name }}
+          path: |
+            Medict_${{ env.VERSION }}_${{ matrix.name }}.zip
+            Medict_${{ env.VERSION }}_${{ matrix.name }}.dmg
+            Medict_${{ env.VERSION }}_${{ matrix.name }}.tar.gz
+          if-no-files-found: error
 
   release:
+    name: Publish release
+    needs: build
     runs-on: ubuntu-latest
-    needs: package
     steps:
-      - name: Get version tag (unix)
-        if: matrix.platform != 'windows-2019'
-        id: version
-        run: echo "::set-output name=tag::v-3.0.1-alpha-${GITHUB_SHA:0:6}"
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Get changelog url
-        id: changelog
-        run: echo "${{ steps.version.outputs.tag }}---$(date +'%Y-%m-%d')" | sed -e 's/\.//g' | awk '{print "::set-output name=url::https://github.com/terasum/medict/blob/develop/CHANGELOG.md#" $1}'
-
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          release_name: ${{ steps.version.outputs.tag }}
-          body: "Medict Nightly build release: <h1>${{ steps.version.outputs.tag }}</h1>"
-          draft: true
-          prerelease: false
+          path: assets
+          merge-multiple: true
 
-      - name: Download all release packages
-        uses: actions/download-artifact@v4.1.7
+      - name: List artifacts
+        run: ls -lhR assets
 
-      - name: Attach darwin disk image
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Release notes = the top `## vX.Y.Z` section of CHANGELOG.md (everything
+      # up to the next `## `). Empty if CHANGELOG.md has no matching section.
+      - name: Collect release notes from CHANGELOG.md
+        id: notes
+        run: |
+          {
+            echo "body<<EOF"
+            awk '/^## /{c++} c==1{print} c==2{exit}' CHANGELOG.md
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create / update GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg/Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg
-          asset_name: Medict_${{ steps.version.outputs.tag }}_Darwin_x86_64.dmg
-          asset_content_type: application/octet-stream
-
-      - name: Attach linux tar.gz
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz/Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz
-          asset_name: Medict_${{ steps.version.outputs.tag }}_Linux_x86_64.tar.gz
-          asset_content_type: application/octet-stream
-
-      - name: Attach windows zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Medict_Windows_x86_64.zip/Medict_Windows_x86_64.zip
-          asset_name: Medict_Windows_x86_64.zip
-          asset_content_type: application/octet-stream
-
-        # - name: Attach linux app image
-        #   uses: actions/upload-release-asset@v1
-        #   env:
-        #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #   with:
-        #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-        #     asset_path: Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage/Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage
-        #     asset_name: Wombat_${{ steps.version.outputs.tag }}_Linux_x86_64.AppImage
-        #     asset_content_type: application/octet-stream
+          tag_name: ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
+          body: ${{ steps.notes.outputs.body }}
+          files: |
+            assets/*.zip
+            assets/*.dmg
+            assets/*.tar.gz
+          # tag push -> published; manual dispatch -> draft (validation only)
+          draft: ${{ github.event_name == 'workflow_dispatch' }}
+          # v3.1.0 -> stable; v3.1.0-rc1 / v3.1.0-beta -> prerelease
+          prerelease: ${{ contains(env.VERSION, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to [Medict](https://github.com/terasum/medict) are recorded
+here. The most recent release is at the top. For the full history before
+v3.1.0, see `git log v3.0.1..HEAD`.
+
+## v3.1.0
+
+First release since v3.0.1. Bundles the reliability, fuzzy-search, and build
+modernization work from the 2024–2026 cycle.
+
+### Added
+
+- **Mdict fuzzy search** (#666 / #697): lookups are prefix-first, with an
+  in-memory BK-tree (character-level Levenshtein, tolerance 2) fallback when the
+  prefix misses — so near-misses still find the entry.
+- **leveldb indexer** is now the active index engine; each `.mdx` gets a
+  `.melev` sidecar cache, and the BK-tree is rebuilt lazily for users whose
+  cache skips `BuildIndex`.
+- **PR-level CI** (backend `go build`/`vet`/`test` + frontend `bun build`)
+  on every pull request to `develop`/`master`. (#701)
+- **Architecture guide** (`CLAUDE.md`) documenting the two-channel (Wails IPC +
+  embedded Gin server) design for contributors and AI assistants.
+
+### Fixed
+
+- `entry://` links whose IDs contain `=`, `/`, `.` etc. (e.g.
+  `entry://topic_transport-by-water_level=c1`) no longer trigger a system
+  "There is no application set to open the URL" dialog — in-iframe jumps now
+  work, with a client-side click interceptor as a safety net. (#718)
+- **Word-lookup main flow** (#707): declarative iframe, fixed a global
+  keyboard-listener leak, and a last-write-wins guard on `searchWord` so fast
+  consecutive lookups no longer race.
+- **Startup robustness** (#705): init failures surface as a dialog instead of
+  crashing the app.
+- **History stack back/forward** (#699): a `keyword`/`key_word` field mix-up
+  broke navigation; the field is now unified to `keyword`.
+- **Wails IPC browser fallback** (#700): the browser path returned `undefined`
+  due to a missing `return`.
+- `GracefulStop` no longer calls `log.Fatal`/`os.Exit` on a shutdown error. (#683)
+- `DictService` singleton is now race-free (`sync.Once`).
+- **CORS** restricted to a local allowlist instead of reflecting any `Origin`.
+- Correct `Content-Type` for `woff2` fonts; correct static-server URL prefix
+  check.
+- Stardict index type distinguished from Mdict; symlinked dictionary
+  directories are followed.
+
+### Changed
+
+- Frontend package manager migrated **pnpm → bun**. (#695)
+- Backend loggers given meaningful per-package identifiers (#704);
+  `DictService` lock granularity tightened so no I/O runs while holding the
+  lock.
+- Frontend dead code and unused dependencies removed. (#703)
+
+### Build / Infrastructure
+
+- Bumped to **Go 1.25**; upgraded `golang.org/x/*` and `logrus`. (#690)
+- Re-enabled and modernized the **release pipeline**: tag-triggered, Go 1.25,
+  modern actions, three platforms (macOS universal, Linux x86_64, Windows
+  x86_64), correct version injection on every platform.
+- Cleared `develop`-branch `go vet`/test debt to keep CI green. (#715)
+
+> Note: the previous automated release workflow had been silently failing on
+> every `develop` push for months (stale Go version, retired runners, deprecated
+> actions). It has been replaced by the tag-triggered pipeline above.


### PR DESCRIPTION
## 背景

`package-and-release.yaml` 已经**长期损坏、且每次 develop 合并都在失败**。`gh run list` 显示 #713/#698/#714/#716/#717/#719 每次都 8~10s 失败，根本没到 `wails build`。最后一份 release 停在 2024-06 的 draft。

损坏点（全在旧 workflow 里）：

| 问题 | 旧值 | 后果 |
|---|---|---|
| Go 版本 | `1.21.x` | 代码需 1.25，无法构建 |
| Linux runner | `ubuntu-20.04` | GitHub 已下线 |
| Actions | `checkout/setup-go/upload-artifact @v2`、`create-release/upload-release-asset @v1` | 全部废弃停用 |
| release job 用 `matrix.platform` | matrix 只在 build job 定义 | 版本号 step 被跳过，资产名全空 |
| 触发 | `push: branches:[master,develop]` + `draft:true` | 每次合并出 `v-3.0.1-alpha-<sha>` 垃圾 draft |
| Windows ldflag | `-X medict/internal/app.semver=unknown` | 符号不存在（实际是 `main.Version`）→ Win 永远 `"dev"` |
| macOS 产物 | `macos-latest`(arm64) 命名 `x86_64.dmg` | 架构标注错 |
| 版本来源 | `v-3.0.1-alpha-${SHA:0:6}` 硬编码 | 与 tag 无关 |

## 改动

**`.github/workflows/package-and-release.yaml`** — 完整重写为可复用管线：

- **触发**：`push: tags: v*` 自动发版；`workflow_dispatch` 手动跑（产出 **draft**，用于验证，可删）
- **版本**：tag push 取 `GITHUB_REF_NAME`，dispatch 取输入；统一 `-ldflags "-X main.Version=<ver>"` 注入，**修掉 Windows 那个错误符号**
- **构建**：`go 1.25.x` + `oven-sh/setup-bun@v2` + `wails build -platform`，matrix：
  - `macos-14` → `darwin/universal`（一个 universal 产物，不再 x86/arm 分裂）
  - `ubuntu-22.04` → `linux/amd64`（装 `libgtk-3-dev libwebkit2gtk-4.0-dev`）
  - `windows-latest` → `windows/amd64`
- **产物**：macOS `.app.zip`（必出）+ `.dmg`（best-effort，复用 `build/assets/darwin`）；Linux `.tar.gz`；Windows `.zip`
- **发布**：`softprops/action-gh-release@v2` 汇总全部产物，从 `CHANGELOG.md` 顶部 `## vX.Y.Z` 段自动抽取发版说明；含 `-` 视为 prerelease；仅 `workflow_dispatch` 为 draft
- 全部用现代 actions（`@v4`/`@v5`/`@v2`），`permissions: contents: write`

**`CHANGELOG.md`** — 从空补齐 `v3.1.0` 段（基于 `v3.0.1..develop` 真实提交，按 Added / Fixed / Changed / Build·Infra 分组）。

## 验证

- YAML 语法校验通过（`PyYAML safe_load`），triggers / jobs / matrix / env 表达式均符合预期
- CHANGELOG 抽取脚本（release job 里那段 `awk`）在本地对真实 CHANGELOG 跑过，正确输出 v3.1.0 段
- 端到端构建（三平台 `wails build`）**无法在本机验证**（本地无 wails/GTK），留给合并后的一次 `workflow_dispatch`

## 合并后如何发 v3.1.0

1. **先 dry-run**：Actions UI → "Release" → Run workflow → `version=v3.1.0-dryrun`。确认三平台产物都生成、draft release 资产齐全。
2. 删除该 draft release 和它产生的 `v3.1.0-dryrun` tag。
3. **正式发版**：
   ```bash
   git tag v3.1.0
   git push --tags
   ```
   管线自动出三平台产物 + published release（CHANGELOG 顶部段作为说明）。
4. （可选）清理那一堆历史 `v-3.0.1-alpha-*` draft release。

## 不在本 PR 范围

- About 页运行时显示 `main.Version`（发版后用户看不到版本号，非阻塞，建议后续单独加）
- 代码签名 / 公证（macOS notarization、Windows authenticode）—— 需要证书，后续单独做
- 自动 prerelease→stable 流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)