### PR TITLE
fix(release): macOS .app.zip 写到根目录以便上传

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -64,11 +64,12 @@ jobs:
         run: wails build -platform ${{ matrix.target }} -ldflags "-X main.Version=${{ env.VERSION }}"
 
       # ---- macOS: always ship a zipped .app; dmg is best-effort ----
+      # Write the .zip to the repo root (GITHUB_WORKSPACE), same as the .dmg /
+      # .tar.gz / Windows .zip, so the shared upload-artifact step picks it up.
       - name: Package macOS (.app zip)
         if: runner.os == 'macOS'
         run: |
-          cd build/bin
-          ditto -c -k --keepParent Medict.app "../Medict_${{ env.VERSION }}_${{ matrix.name }}.zip"
+          ditto -c -k --keepParent build/bin/Medict.app "Medict_${{ env.VERSION }}_${{ matrix.name }}.zip"
 
       - name: Package macOS (.dmg)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## 问题

v3.1.0 发版时发现 macOS 的 `.app.zip` 兜底产物**从未进入 release assets**——release 里只有 `.dmg` / `.tar.gz` / Windows `.zip`，缺 macOS 的 `.zip`。

## 根因

```yaml
- name: Package macOS (.app zip)
  run: |
    cd build/bin
    ditto -c -k --keepParent Medict.app "../Medict_..._Darwin_universal.zip"
```

`cd build/bin` + `../` 把 `.zip` 写到了 **`build/`** 目录，而 `upload-artifact` 的 `path` 是相对仓库根（`GITHUB_WORKSPACE`）查找的 → 路径不匹配 → 该文件被静默跳过（同 matrix 的 `.dmg` 在根目录所以照常上传，`if-no-files-found: error` 没触发）。

## 修复

去掉 `cd build/bin`，直接把 `.app.zip` 写到仓库根，和 `.dmg` / `.tar.gz` / Windows `.zip` 保持一致：

```yaml
run: |
  ditto -c -k --keepParent build/bin/Medict.app "Medict_..._Darwin_universal.zip"
```

## 验证

- YAML 语法校验通过
- 与其它 3 个 packaging step（都已写到根目录且 v3.1.0 验证过可正常上传）完全一致，路径逻辑确定
- 端到端需在合并后用 `workflow_dispatch` dry-run 验证 macOS `.zip` 出现在 assets 里

## 影响

不影响 v3.1.0（已发布，macOS 由 `.dmg` 覆盖）。下次发版（v3.1.1+）macOS 会同时有 `.zip` + `.dmg`，且当 dmg 步骤失败（`continue-on-error`）时 `.zip` 仍能兜底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)