### PR TITLE
fix(indexer): strip() TrimLeft→TrimPrefix，修复 P/F/K/W 开头词前缀搜索 (#722 P0)

### DIFF
--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"github.com/terasum/medict/pkg/model"
 	lvdb "github.com/terasum/medict/pkg/service/mdict/leveldb-repo"
-	"regexp"
 	"strings"
 )
 
@@ -14,16 +13,18 @@ var _ Indexer = &MedictDBIndexer{}
 const prefixKeyword = "PFKW#_"
 const prefixMeta = "PFMT#_"
 
-var regex = regexp.MustCompile("/[., '\\\\@_\\$#\\%\\:\\/]/g")
-
 type MedictDBIndexer struct {
 	indexFileDirPath string
 	lvdb             *lvdb.LvDB
 	//searchTree       *searchTree
 }
 
+// strip namespaces a keyword under the PFKW#_ prefix so keyword keys never
+// collide with the PFMT#_-prefixed meta keys. TrimPrefix (not TrimLeft, which
+// treats its arg as a *cutset* and would silently eat leading P/F/K/W/#/_
+// chars off the keyword itself — see issue #722) avoids double-prefixing.
 func strip(key string) string {
-	return prefixKeyword + strings.TrimLeft(regex.ReplaceAllString(key, ""), prefixKeyword)
+	return prefixKeyword + strings.TrimPrefix(key, prefixKeyword)
 }
 
 func NewIndexer(fpath string) (*MedictDBIndexer, error) {

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
@@ -1,8 +1,27 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package mdict_idxer
 
 import (
-	"github.com/terasum/medict/pkg/model"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/terasum/medict/pkg/model"
 )
 
 func TestLookup(t *testing.T) {
@@ -36,5 +55,48 @@ func TestLookup(t *testing.T) {
 	}
 	for _, w := range list {
 		t.Logf("search word: %s", w.KeyWord)
+	}
+}
+
+// Regression for issue #722 P0: strip() used strings.TrimLeft(cutset) where it
+// meant strings.TrimPrefix, which trimmed any leading P/F/K/W/#/_ off the
+// keyword. That collapsed distinct words onto one key ("King" and "ing" both =>
+// "PFKW#_ing", one overwriting the other) and made prefix searches for P/F/K/W
+// -initial words return the wrong cluster ("Kin" scanned "PFKW#_in").
+func TestStrip_NoCollisionForPrefixInitialWords(t *testing.T) {
+	idxer, err := NewIndexer(filepath.Join(t.TempDir(), "testleveldb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	add := func(kw string) {
+		if err := idxer.AddRecord(&model.MdictKeyWordIndex{KeyWord: kw}); err != nil {
+			t.Fatalf("AddRecord(%q): %v", kw, err)
+		}
+	}
+	// "King" and "ing": the buggy strip() mapped both to "PFKW#_ing".
+	add("King")
+	add("ing")
+
+	for _, kw := range []string{"King", "ing"} {
+		got, err := idxer.Lookup(kw)
+		if err != nil {
+			t.Fatalf("Lookup(%q) error: %v (strip collision?)", kw, err)
+		}
+		if got.KeyWord != kw {
+			t.Fatalf("Lookup(%q) returned %q (strip collision overwrote it)", kw, got.KeyWord)
+		}
+	}
+
+	// Prefix search "Kin" must return only King-prefixed words, never the "ing"
+	// cluster the buggy strip() produced (it scanned "PFKW#_in").
+	res, err := idxer.Search("Kin")
+	if err != nil {
+		t.Fatalf("Search(Kin) error: %v", err)
+	}
+	for _, r := range res {
+		if !strings.HasPrefix(r.KeyWord, "Kin") {
+			t.Fatalf("Search(Kin) returned %q — strip TrimLeft bug leaked the wrong cluster", r.KeyWord)
+		}
 	}
 }


### PR DESCRIPTION
> Issue: #722（本 PR 处理其中的 **P0** 项；其余设计/性能债务在该 issue checklist 跟踪）

## 问题

`mdict-idxer/leveldb_indexer.go` 的 `strip()` 把 `strings.TrimPrefix` 误写成了 `strings.TrimLeft`：

```go
func strip(key string) string {
	return prefixKeyword + strings.TrimLeft(regex.ReplaceAllString(key, ""), prefixKeyword)
}
```

`TrimLeft(s, cutset)` 第二个参数是**字符集合**，不是前缀串。结果 keyword 开头属于 `{P,F,K,W,#,_}` 的字符被砍掉。实测：

```
King   => PFKW#_ing      ing  => PFKW#_ing      ← 碰撞，AddRecord 互相覆盖
Plant  => PFKW#_lant     lant => PFKW#_lant     ← 碰撞
search("Kin") 扫描 "PFKW#_in"  → 返回 "in..." 词簇，不是 "Kin..." 词
search("Wat") 与 search("Fat") 扫描同一个 "PFKW#_at" → 返回完全相同结果
```

**影响**：搜 `Pla`（期望 Place/Plant）会拿到 `la...` 词；`King`/`ing` 共存时互相覆盖。英文 P/F/K/W 是高频首字母，**前缀搜索对这类词实际是坏的**。精确 Lookup 因「存取都 mangle」多数仍命中，所以一直没被发现。

## 修复

- `TrimLeft` → `TrimPrefix`：只去掉可能已存在的前缀，不再误删 keyword 首字符。
- 删除第 17 行 JS 风格的 dead `regex`（`/[., ...]/g`，在 Go RE2 永不匹配，是 strip 里从未生效的「去标点」残留）及 `regexp` 导入。

## 验证（red-green）

新增 `TestStrip_NoCollisionForPrefixInitialWords`（用 `t.TempDir()` 隔离，不污染既有 testdata）：

- 修复**前**：FAIL —— `Lookup("King") returned "ing"`（碰撞被覆盖）
- 修复**后**：PASS

```
ok  github.com/terasum/medict/pkg/service/mdict/mdict-idxer
ok  github.com/terasum/medict/pkg/service/mdict
```
`go vet ./pkg/service/mdict/mdict-idxer/` 干净。

## 附带观察（不在本 PR 范围）

- 现有 `TestLookup` 用 `./testdata/testleveldb`（已入库的磁盘 leveldb），每次运行会改写其内部文件（CURRENT/LOG/MANIFEST 等）—— 这是独立的测试卫生问题，建议改用 `t.TempDir()`，留作 #722 之外的小清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)