### PR TITLE
fix(indexer): 移除 leveldb 连接池，修复 BuildIndex nil 连接 panic (#722)

### DIFF
--- a/pkg/service/mdict/leveldb-repo/leveldb.go
+++ b/pkg/service/mdict/leveldb-repo/leveldb.go
@@ -1,108 +1,55 @@
 package leveldb_repo
 
 import (
-	"github.com/silenceper/pool"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
-	"time"
 )
 
+// LvDB wraps a single embedded leveldb handle.
+//
+// goleveldb's *leveldb.DB is itself goroutine-safe, so one shared handle serves
+// all callers — no connection pool needed. The previous silenceper/pool design
+// could hand out a nil connection when its idle reaper tried to re-open the
+// same file and tripped goleveldb's flock, then panicked on the unchecked
+// db.(*leveldb.DB) assertion in acquire (issue #722, live panic during
+// BuildIndex). Holding one handle removes that failure class entirely.
 type LvDB struct {
 	dbFileDirPath string
-	connPool      pool.Pool
+	db            *leveldb.DB
 }
 
 func NewLvDB(fpath string) (*LvDB, error) {
-	connPool, err := pool.NewChannelPool(&pool.Config{
-		InitialCap: 1,
-		MaxCap:     3,
-		MaxIdle:    3,
-		Factory: func() (interface{}, error) {
-			db, err1 := leveldb.OpenFile(fpath, nil)
-			if err1 != nil {
-				return nil, err1
-			}
-			return db, nil
-		},
-		Close: func(db interface{}) error {
-			return db.(*leveldb.DB).Close()
-		},
-		Ping: func(db interface{}) error {
-			return nil
-		},
-		IdleTimeout: 60 * time.Second,
-	})
+	db, err := leveldb.OpenFile(fpath, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	idxer := &LvDB{
+	return &LvDB{
 		dbFileDirPath: fpath,
-		connPool:      connPool,
-	}
-	return idxer, nil
+		db:            db,
+	}, nil
 }
 
-func (lvdb *LvDB) acquire() (*leveldb.DB, error) {
-	db, err := lvdb.connPool.Get()
-	return db.(*leveldb.DB), err
-}
-
-func (lvdb *LvDB) release(db *leveldb.DB) {
-	err := lvdb.connPool.Put(db)
-	if err != nil {
-		log.Errorf(err.Error())
-	}
-}
-
-// Prefix retrieve keys list from leveldb
+// Prefix returns the keys with the given prefix, in leveldb's sorted order.
 func (lvdb *LvDB) Prefix(prefix string) ([]string, error) {
-	db, err := lvdb.acquire()
-	if err != nil {
-		return nil, err
-	}
-	defer lvdb.release(db)
-	ite := db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
+	ite := lvdb.db.NewIterator(util.BytesPrefix([]byte(prefix)), nil)
+	defer ite.Release()
 
 	result := make([]string, 0)
 	for ite.Next() {
 		result = append(result, string(ite.Key()))
 	}
+	if err := ite.Error(); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
-// Put a key-value pair into leveldb
+// Put a key-value pair into leveldb.
 func (lvdb *LvDB) Put(key string, value []byte) error {
-	db, err := lvdb.acquire()
-	if err != nil {
-		return err
-	}
-	defer lvdb.release(db)
-
-	return db.Put([]byte(key), value, nil)
+	return lvdb.db.Put([]byte(key), value, nil)
 }
 
-// Get a key-value pair from leveldb
+// Get a key-value pair from leveldb.
 func (lvdb *LvDB) Get(key string) ([]byte, error) {
-	db, err := lvdb.acquire()
-	if err != nil {
-		return nil, err
-	}
-	defer lvdb.release(db)
-	value, err := db.Get([]byte(key), nil)
-	return value, err
+	return lvdb.db.Get([]byte(key), nil)
 }
-
-//func sortList(keyword string, list []*model.MdictKeyWordIndex) (error) {
-//	wrapper := &entryWrapper{
-//		list: make([]*entryWrapperItem, 0),
-//	}
-//
-//	distance := levenshtein.Distance(keyword, valueIndex.KeyWord)
-//	wrapper.list = append(wrapper.list, &entryWrapperItem{
-//		entry:    valueIndex,
-//		distance: distance,
-//	})
-//	sort.Sort(wrapper)
-//	return nil
-//}

--- a/pkg/service/mdict/leveldb-repo/leveldb_test.go
+++ b/pkg/service/mdict/leveldb-repo/leveldb_test.go
@@ -1,0 +1,115 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package leveldb_repo
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestLvDB_PutGetPrefix(t *testing.T) {
+	db, err := NewLvDB(filepath.Join(t.TempDir(), "kv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Put("PFKW#_apple", []byte("a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Put("PFKW#_apply", []byte("b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Put("PFKW#_banana", []byte("c")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.Get("PFKW#_apple")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "a" {
+		t.Fatalf("Get = %q, want %q", got, "a")
+	}
+
+	keys, err := db.Prefix("PFKW#_app")
+	if err != nil {
+		t.Fatalf("Prefix: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("Prefix returned %d keys, want 2: %v", len(keys), keys)
+	}
+}
+
+// TestLvDB_ConcurrentAccess guards the single-handle design (issue #722): the
+// old silenceper/pool wrapper could return a nil connection and panic in
+// acquire under concurrent load. The shared *leveldb.DB must tolerate
+// concurrent Put/Get/Prefix without panicking or losing writes.
+func TestLvDB_ConcurrentAccess(t *testing.T) {
+	db, err := NewLvDB(filepath.Join(t.TempDir(), "concurrent"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const writers = 4
+	const perWriter = 200
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				key := fmt.Sprintf("k%d-%04d", id, i)
+				if err := db.Put(key, []byte(key)); err != nil {
+					t.Errorf("Put(%s): %v", key, err)
+					return
+				}
+				if v, err := db.Get(key); err != nil {
+					t.Errorf("Get(%s): %v", key, err)
+					return
+				} else if string(v) != key {
+					t.Errorf("Get(%s) = %q", key, v)
+					return
+				}
+			}
+		}(w)
+	}
+
+	// Concurrent prefix scans while writes are in flight.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			if _, err := db.Prefix("k"); err != nil {
+				t.Errorf("Prefix: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	keys, err := db.Prefix("k")
+	if err != nil {
+		t.Fatalf("final Prefix: %v", err)
+	}
+	if got, want := len(keys), writers*perWriter; got != want {
+		t.Fatalf("after concurrent writes got %d keys, want %d", got, want)
+	}
+}


### PR DESCRIPTION
> Issue: #722 P1（连接池）。这是**线上 panic 的止血修复**，优先合并。

## 线上 panic

```
panic: interface conversion: interface {} is nil, not *leveldb.DB
  LvDB.acquire (leveldb.go)        # db.(*leveldb.DB) 断言 nil
  ← LvDB.Put ← AddRecord ← mdictHolder.BuildIndex ← BuildIndexByDictId
```

复现：在「使用说明」界面点搜索 → `BuildIndexByDictId` → `BuildIndex` → `AddRecord` → `LvDB.Put` → `acquire` 崩溃。

## 根因

`LvDB` 用 `silenceper/pool` 封装嵌入式 leveldb。池空闲连接被 `IdleTimeout` 回收后，重建走 `leveldb.OpenFile`，因 goleveldb 的 flock（同进程已持有同一文件的锁）失败 → `pool.Get()` 返回 `(nil, err)` → `acquire` 对 nil 做无保护类型断言 `db.(*leveldb.DB)` → panic。

这正是 #722 审查里 P1「连接池是错误抽象」那条——此前判断是隐患，现在因实际触发升级为线上崩溃。

## 修复（最小止血范围，仅一个文件）

`pkg/service/mdict/leveldb-repo/leveldb.go`：
- 去掉 `silenceper/pool` 与 `acquire`/`release`；`LvDB` 直接持单一 `*leveldb.DB`。
- `NewLvDB` 一次 `leveldb.OpenFile`，存单句柄。
- `Put`/`Get`/`Prefix` 直接用 `lvdb.db`（goleveldb 本身并发安全，单句柄服务所有调用者）。
- `Prefix` 补 `defer ite.Release()` 与 `ite.Error()` 检查。
- 删除 `pool`、`time` 导入。

按构造消除 nil-连接断言路径 → 这一类 panic 不复存在。

## 验证

新增 `leveldb_test.go`：
- `TestLvDB_PutGetPrefix`：基本 Put/Get/Prefix 正确性。
- `TestLvDB_ConcurrentAccess`：4 写协程 ×200 key + 并发 Prefix 扫描，**`-race` 下无 panic、无数据丢失**（旧 pool 设计在此类负载下可能崩）。

```
go test -race ./pkg/service/mdict/...   全绿
go vet ./pkg/...                         干净
go build ./...                           通过
```

## 不在本 PR 范围

`Close()` 生命周期、batch 构建、Search N+1、`search_tree.go`/`sqlite_indexer.go` 死代码清理、日志降级等其余 #722 checklist 项，按计划在后续 PR 推进（保持止血范围最小，尽快合并解掉线上 panic）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)