### PR TITLE
feat(indexer): Close 生命周期全链路 + shutdown 钩子 (#722 P1)

### DIFF
--- a/app.go
+++ b/app.go
@@ -26,6 +26,7 @@ import (
 	"github.com/terasum/medict/internal/utils"
 	"github.com/terasum/medict/pkg/backserver"
 	"github.com/terasum/medict/pkg/model"
+	"github.com/terasum/medict/pkg/service"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 )
 
@@ -94,6 +95,12 @@ func (b *App) shutdown(ctx context.Context) {
 	close(b.stopChannel)
 	close(b.errorChannel)
 	b.bs.GracefulStop()
+	// Release per-dictionary resources (leveldb handles, etc.).
+	if ds := service.GetDictService(); ds != nil {
+		if err := ds.Close(); err != nil {
+			log.Errorf("shutdown: close dictionaries failed: %s", err.Error())
+		}
+	}
 }
 
 func (b *App) Dispatch(apiName string, args map[string]interface{}) *model.Resp {

--- a/pkg/model/dict_interface.go
+++ b/pkg/model/dict_interface.go
@@ -25,4 +25,6 @@ type GeneralDictionary interface {
 	Locate(entry *KeyQueryIndex) ([]byte, error)
 	// Search 返回近似词条索引列表，用于后续 Locate
 	Search(keyword string) ([]*KeyQueryIndex, error)
+	// Close 释放该词典持有的底层资源（如 leveldb 句柄），供应用关闭时调用
+	Close() error
 }

--- a/pkg/service/dicts_service.go
+++ b/pkg/service/dicts_service.go
@@ -54,6 +54,32 @@ func NewDictService(config *config.Config) (*DictService, error) {
 	return singltonInstanceDictService, nil
 }
 
+// GetDictService returns the process-wide DictService singleton, or nil if
+// NewDictService has not run yet (e.g. app init failed before SetUp).
+func GetDictService() *DictService {
+	return singltonInstanceDictService
+}
+
+// Close releases resources held by all loaded dictionaries (e.g. leveldb
+// handles). Intended for app shutdown: errors from individual dicts are logged
+// and joined, and never block closing the rest.
+func (ds *DictService) Close() error {
+	ds.dictLock.Lock()
+	defer ds.dictLock.Unlock()
+
+	var errs []error
+	for _, dict := range ds.dicts {
+		if dict.MainDict == nil {
+			continue
+		}
+		if err := dict.MainDict.Close(); err != nil {
+			log.Errorf("close dict %s failed: %s", dict.ID, err.Error())
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // InitDicts initialize the dictionaries
 func (ds *DictService) InitDicts() error {
 	return ds.walkDicts()

--- a/pkg/service/mdict/leveldb-repo/leveldb.go
+++ b/pkg/service/mdict/leveldb-repo/leveldb.go
@@ -53,3 +53,9 @@ func (lvdb *LvDB) Put(key string, value []byte) error {
 func (lvdb *LvDB) Get(key string) ([]byte, error) {
 	return lvdb.db.Get([]byte(key), nil)
 }
+
+// Close releases the leveldb handle. Operations after Close return leveldb's
+// ErrClosed rather than panicking.
+func (lvdb *LvDB) Close() error {
+	return lvdb.db.Close()
+}

--- a/pkg/service/mdict/leveldb-repo/leveldb_test.go
+++ b/pkg/service/mdict/leveldb-repo/leveldb_test.go
@@ -56,6 +56,24 @@ func TestLvDB_PutGetPrefix(t *testing.T) {
 	}
 }
 
+// TestLvDB_UseAfterCloseErrors verifies Close releases the handle and later
+// ops return an error (leveldb's ErrClosed) instead of panicking.
+func TestLvDB_UseAfterCloseErrors(t *testing.T) {
+	db, err := NewLvDB(filepath.Join(t.TempDir(), "close"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := db.Get("anything"); err == nil {
+		t.Fatal("Get after Close: want error, got nil")
+	}
+	if err := db.Put("k", []byte("v")); err == nil {
+		t.Fatal("Put after Close: want error, got nil")
+	}
+}
+
 // TestLvDB_ConcurrentAccess guards the single-handle design (issue #722): the
 // old silenceper/pool wrapper could return a nil connection and panic in
 // acquire under concurrent load. The shared *leveldb.DB must tolerate

--- a/pkg/service/mdict/mdict-idxer/indexer.go
+++ b/pkg/service/mdict/mdict-idxer/indexer.go
@@ -8,4 +8,7 @@ type Indexer interface {
 	GetMeta(key string) (value string, err error)
 	AddRecord(record *model.MdictKeyWordIndex) error
 	Search(keyword string) ([]*model.MdictKeyWordIndex, error)
+	// Close releases the underlying store handle. Use after Close returns an
+	// error (not a panic).
+	Close() error
 }

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
@@ -45,6 +45,14 @@ func NewIndexer(fpath string) (*MedictDBIndexer, error) {
 
 }
 
+// Close releases the underlying leveldb handle.
+func (m *MedictDBIndexer) Close() error {
+	if m.lvdb == nil {
+		return nil
+	}
+	return m.lvdb.Close()
+}
+
 func (m *MedictDBIndexer) Lookup(keyword string) (*model.MdictKeyWordIndex, error) {
 	key := strip(keyword)
 	data, err := m.lvdb.Get(key)

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
@@ -24,6 +24,26 @@ import (
 	"github.com/terasum/medict/pkg/model"
 )
 
+// TestIndexer_CloseReleasesHandle verifies Close releases the leveldb handle;
+// operations after Close return an error (not a panic). Guards the Close
+// lifecycle added for issue #722.
+func TestIndexer_CloseReleasesHandle(t *testing.T) {
+	idxer, err := NewIndexer(filepath.Join(t.TempDir(), "idxclose"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idxer.AddRecord(&model.MdictKeyWordIndex{KeyWord: "x"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := idxer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// After Close, operations must error (leveldb ErrClosed), not panic.
+	if _, err := idxer.Lookup("x"); err == nil {
+		t.Fatal("Lookup after Close: want error, got nil")
+	}
+}
+
 func TestLookup(t *testing.T) {
 
 	idxer, err := NewIndexer("./testdata/testleveldb")

--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -124,6 +124,15 @@ func (mh *mdictHolder) Locate(entry *model.MdictKeyWordIndex) ([]byte, error) {
 	return def, nil
 }
 
+// Close releases the indexer's leveldb handle. (The raw .mdx parser handle is
+// not released here — it exposes no Close; tracked separately.)
+func (mh *mdictHolder) Close() error {
+	if mh.idxer != nil {
+		return mh.idxer.Close()
+	}
+	return nil
+}
+
 func (mh *mdictHolder) Lookup(keyword string) ([]byte, error) {
 	entry, err := mh.idxer.Lookup(keyword)
 	if err != nil {

--- a/pkg/service/mdict/mdict_holder_fuzzy_test.go
+++ b/pkg/service/mdict/mdict_holder_fuzzy_test.go
@@ -27,6 +27,7 @@ func (f *fakeIdxer) AddRecord(record *model.MdictKeyWordIndex) error { return ni
 func (f *fakeIdxer) Search(keyword string) ([]*model.MdictKeyWordIndex, error) {
 	return nil, errors.New("result not found")
 }
+func (f *fakeIdxer) Close() error { return nil }
 
 // TestFuzzyFallback verifies that a prefix miss routes through the BK-tree
 // fallback and returns the closest matches (sorted by distance).

--- a/pkg/service/mdict/mdict_svc.go
+++ b/pkg/service/mdict/mdict_svc.go
@@ -52,6 +52,22 @@ func (md *mdictSvcImpl) Description() *model.PlainDictionaryInfo {
 	}
 }
 
+// Close releases the underlying indexers of the mdx and all mdd holders.
+func (md *mdictSvcImpl) Close() error {
+	var errs []error
+	if md.mdx != nil {
+		if err := md.mdx.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	for _, mdd := range md.mdds {
+		if err := mdd.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func (md *mdictSvcImpl) BuildIndex() error {
 	if md.hasBuildIndex {
 		return nil

--- a/pkg/service/stardict/startdict.go
+++ b/pkg/service/stardict/startdict.go
@@ -44,6 +44,12 @@ func (bs *bkString) Distance(entry bktree.Entry) int {
 	return levenshtein.Distance(bs.w, entry.(*bkString).w)
 }
 
+// Close is a no-op for StarDict: it holds no leveldb/database handles, only
+// in-memory structures (BKTree) and the parsed stardict data.
+func (s *StarDict) Close() error {
+	return nil
+}
+
 func (s *StarDict) BuildIndex() error {
 	if s.ready {
 		return nil


### PR DESCRIPTION
> Issue: #722 P1（生命周期）。续 PR #724（panic 止血）之后的第 2 步。

## 问题

#722 P1：indexer / LvDB / holder / DictService 全链路无 `Close`，leveldb 句柄与文件锁只能随进程退出释放——无法优雅关闭，也无法热重建词典。

## 修复（贯穿 Close）

从底向上加 `Close() error`，逐层委托：

| 层 | 文件 | 行为 |
|---|---|---|
| LvDB | `leveldb-repo/leveldb.go` | `db.Close()` |
| Indexer 接口 | `mdict-idxer/indexer.go` | +`Close() error` |
| leveldb indexer | `mdict-idxer/leveldb_indexer.go` | 委托 LvDB.Close |
| GeneralDictionary 接口 | `model/dict_interface.go` | +`Close() error` |
| mdictHolder | `mdict/mdict_holder.go` | `idxer.Close()` |
| mdictSvcImpl | `mdict/mdict_svc.go` | 关 mdx + 所有 mdds（`errors.Join`） |
| StarDict | `stardict/startdict.go` | no-op（仅内存结构） |
| DictService | `service/dicts_service.go` | dictLock 下遍历 dicts 调 `MainDict.Close`，逐个错误记日志不阻断 |
| 包级 getter | `service/dicts_service.go` | `GetDictService()` 取 singleton |
| 关闭钩子 | `app.go` | `App.shutdown` 接入 `DictService.Close()` |

设计要点：
- `DictService.Close` 持 `dictLock` 串行关闭，单个 dict 关闭失败只记日志、`errors.Join` 汇总，**不阻断其余**关闭。
- `App.shutdown` 经 `GetDictService()` 取单例，nil 安全（init 失败场景）。
- `errors.Join`（Go 1.20+，项目 1.25）汇总多层错误。

## 不在本 PR 范围

- rawdict（.mdx 解析器）未暴露 Close，其文件句柄是独立项，不在 #722 P1 内。
- `sqlite_indexer.go` 无 `Indexer` 接口断言、未被当 Indexer 使用，加 Close 不影响它；其删除留 PR3（与 search_tree 等死代码一起）。

## 验证

```
TestLvDB_UseAfterCloseErrors     Close 后 Get/Put 返回 error 非 panic
TestIndexer_CloseReleasesHandle  indexer Close 后 Lookup 报错非 panic
fakeIdxer (fuzzy test)           补 Close
go build ./...                   通过
go test ./pkg/service/... ./pkg/model/... ./pkg/backserver/...   全绿
go vet ./...                     干净
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)