### PR TITLE
perf(indexer): 模糊搜索 BK-tree 改从 leveldb 构建，不再重解 mdx (#722 #2)

### DIFF
--- a/pkg/service/mdict/mdict-idxer/indexer.go
+++ b/pkg/service/mdict/mdict-idxer/indexer.go
@@ -10,6 +10,9 @@ type Indexer interface {
 	// AddRecords bulk-writes records (used during index builds).
 	AddRecords(records []*model.MdictKeyWordIndex) error
 	Search(keyword string) ([]*model.MdictKeyWordIndex, error)
+	// AllRecords returns every indexed keyword record, used to build in-memory
+	// structures (e.g. the fuzzy BK-tree) without re-parsing the source dict.
+	AllRecords() ([]*model.MdictKeyWordIndex, error)
 	// Close releases the underlying store handle. Use after Close returns an
 	// error (not a panic).
 	Close() error

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
@@ -114,6 +114,27 @@ func (m *MedictDBIndexer) AddRecords(records []*model.MdictKeyWordIndex) (resErr
 	return m.lvdb.Write(batch)
 }
 
+// AllRecords returns every indexed keyword record by scanning the whole
+// PFKW#_ keyspace (meta keys use a different prefix and are excluded). Used to
+// build the in-memory fuzzy BK-tree without re-parsing the source dict
+// (issue #722 #2).
+func (m *MedictDBIndexer) AllRecords() ([]*model.MdictKeyWordIndex, error) {
+	kvs, err := m.lvdb.Prefix(prefixKeyword)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*model.MdictKeyWordIndex, 0, len(kvs))
+	for _, kv := range kvs {
+		r := new(model.MdictKeyWordIndex)
+		if err := json.Unmarshal(kv.Value, r); err != nil {
+			log.Errorf("AllRecords unmarshal failed: %s", err)
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
 func (m *MedictDBIndexer) Search(keyword string) (res []*model.MdictKeyWordIndex, resErr error) {
 	startTime := logstart("MedictDBIndexer.Search", keyword)
 	defer logend("MedictDBIndexer.Search", startTime, resErr)

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
@@ -78,6 +78,39 @@ func TestLookup(t *testing.T) {
 	}
 }
 
+// TestAllRecords: AllRecords returns every keyword record (and excludes the
+// PFMT#_ meta keys). Used by the holder to build the fuzzy BK-tree without
+// re-parsing the source dict (issue #722 #2).
+func TestAllRecords(t *testing.T) {
+	idxer, err := NewIndexer(filepath.Join(t.TempDir(), "all"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idxer.SetMeta("Title", "demo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := idxer.AddRecords([]*model.MdictKeyWordIndex{
+		{KeyWord: "apple", RecordLocateStartOffset: 10},
+		{KeyWord: "banana", RecordLocateStartOffset: 20},
+		{KeyWord: "cherry", RecordLocateStartOffset: 30},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := idxer.AllRecords()
+	if err != nil {
+		t.Fatalf("AllRecords: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("AllRecords returned %d records, want 3 (meta must be excluded)", len(got))
+	}
+	for _, r := range got {
+		if r.KeyWord == "" {
+			t.Fatalf("AllRecords returned a record with empty keyword: %+v", r)
+		}
+	}
+}
+
 // TestAddRecords_BatchEquivalence: AddRecords (leveldb batch) writes records
 // that are individually lookable-up and carry their fields through — i.e. the
 // batch path produces the same observable state as per-record AddRecord.

--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -256,25 +256,23 @@ func (mh *mdictHolder) bktreeAdd(e *model.MdictKeyWordIndex) {
 	mh.bktree.Add(&fuzzyEntry{e})
 }
 
-// ensureBkTree 按需构建 BK-tree，兜底 .melev 缓存命中（幂等守卫跳过 BuildIndex）的场景。
-// 由 mh.lock 保护；eager 路径已在 BuildIndex 构建时本函数是 no-op。
+// ensureBkTree 按需从 leveldb 索引构建 BK-tree（不再重解 mdx），兜底 .melev 缓存
+// 命中、跳过 BuildIndex 的场景：用户也能拿到模糊搜索，且不付全量 mdx 解析代价
+// (issue #722 #2)。由 mh.lock 保护；eager 路径已在 BuildIndex 构建并置 bktreeDone，
+// 本函数对该路径是 no-op。
 func (mh *mdictHolder) ensureBkTree() error {
 	mh.lock.Lock()
 	defer mh.lock.Unlock()
 	if mh.bktreeDone {
 		return nil
 	}
-	entries, err := mh.rawdict.GetKeyWordEntries()
+	records, err := mh.idxer.AllRecords()
 	if err != nil {
 		return err
 	}
 	tree := &bktree.BKTree{}
-	for _, entry := range entries {
-		idx, err1 := mh.ConvertKeyWordIndex(entry)
-		if err1 != nil {
-			continue
-		}
-		tree.Add(&fuzzyEntry{idx})
+	for _, r := range records {
+		tree.Add(&fuzzyEntry{r})
 	}
 	mh.bktree = tree
 	mh.bktreeDone = true

--- a/pkg/service/mdict/mdict_holder_fuzzy_test.go
+++ b/pkg/service/mdict/mdict_holder_fuzzy_test.go
@@ -2,6 +2,7 @@ package mdict
 
 import (
 	"errors"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/terasum/medict/internal/libs/bktree"
 	"github.com/terasum/medict/pkg/model"
+	idxer "github.com/terasum/medict/pkg/service/mdict/mdict-idxer"
 )
 
 // fakeIdxer implements idxer.Indexer; its Search always misses, forcing the
@@ -25,6 +27,7 @@ func (f *fakeIdxer) GetMeta(key string) (string, error) {
 }
 func (f *fakeIdxer) AddRecord(record *model.MdictKeyWordIndex) error { return nil }
 func (f *fakeIdxer) AddRecords(records []*model.MdictKeyWordIndex) error { return nil }
+func (f *fakeIdxer) AllRecords() ([]*model.MdictKeyWordIndex, error)      { return nil, nil }
 func (f *fakeIdxer) Search(keyword string) ([]*model.MdictKeyWordIndex, error) {
 	return nil, errors.New("result not found")
 }
@@ -63,6 +66,31 @@ func TestFuzzyFallback(t *testing.T) {
 	// Distances non-decreasing (ascending).
 	for i := 1; i < len(res); i++ {
 		assert.GreaterOrEqual(t, res[i].ID, res[i-1].ID)
+	}
+}
+
+// TestEnsureBkTree_FromIndexer: with bktreeDone=false (the .melev cache-hit
+// case), ensureBkTree builds the BK-tree from the leveldb index — not by
+// re-parsing the mdx — so fuzzy search still works (issue #722 #2).
+func TestEnsureBkTree_FromIndexer(t *testing.T) {
+	idx, err := idxer.NewIndexer(filepath.Join(t.TempDir(), "bktree"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NoError(t, idx.AddRecords([]*model.MdictKeyWordIndex{
+		{KeyWord: "hello", RecordLocateStartOffset: 100},
+		{KeyWord: "help", RecordLocateStartOffset: 200},
+	}))
+
+	mh := &mdictHolder{lock: &sync.Mutex{}, idxer: idx} // bktreeDone defaults to false
+	assert.NoError(t, mh.ensureBkTree())
+	assert.True(t, mh.bktreeDone)
+
+	// "helo" (typo of hello) resolves via the indexer-built BK-tree.
+	res, err := mh.Search("helo")
+	assert.NoError(t, err)
+	if assert.NotEmpty(t, res) {
+		assert.Equal(t, "hello", res[0].KeyWord)
 	}
 }
 


### PR DESCRIPTION
> Issue: #722 #2（模糊搜索复用缓存）。#722 继 P0/P1/P2/P3（#723–#726）之后的收尾。

## 问题

`.melev` 缓存让前缀/精确查询变快了，但**模糊搜索没变快**：`ensureBkTree` 兜底路径仍调 `rawdict.GetKeyWordEntries()` 全量重解 mdx。缓存命中、跳过 `BuildIndex` 的用户，第一次模糊查询仍付全量 mdx 解析代价。

## 修复

- `Indexer` 接口 +`AllRecords() ([]*MdictKeyWordIndex, error)`。
- `MedictDBIndexer.AllRecords`：`Prefix("PFKW#_")` 全扫反序列化（`PFMT#_` meta 键前缀不同，天然排除），返回全部关键词记录。
- `mdictHolder.ensureBkTree` 改用 `idxer.AllRecords()` 构建 BK-tree，**删除 `rawdict.GetKeyWordEntries()` + `ConvertKeyWordIndex` 路径**——不再碰 mdx。
- `fakeIdxer` 补 `AllRecords` stub。

结果：缓存命中的启动，模糊搜索也只扫 leveldb（有序扫描，内存友好），不再付 mdx 解析代价。

## 验证

```
TestAllRecords                返回全部关键词记录、排除 meta
TestEnsureBkTree_FromIndexer  bktreeDone=false（缓存命中场景）下从 indexer 构建，
                              "helo" 模糊命中 "hello"
go test -race ./pkg/service/...   全绿
go build ./... + go vet ./...     通过
```

## 后续

#722 #1（同名词条碰撞）走 offset-suffix key + schema 迁移，在下一个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)