### PR TITLE
fix(indexer): offset-suffix key 解决同名词条碰撞 + schema 迁移 (#722 #1)

### DIFF
--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer.go
@@ -2,6 +2,7 @@ package mdict_idxer
 
 import (
 	"encoding/json"
+	"strconv"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/terasum/medict/pkg/model"
 	lvdb "github.com/terasum/medict/pkg/service/mdict/leveldb-repo"
@@ -12,6 +13,19 @@ var _ Indexer = &MedictDBIndexer{}
 
 const prefixKeyword = "PFKW#_"
 const prefixMeta = "PFMT#_"
+
+// keySep separates the headword from the per-record disambiguator in a keyword
+// key. "\x1f" (ASCII Unit Separator) does not occur in dictionary keywords, so
+// it cleanly splits "typeahead prefix" from "exact match" (issue #722 #1).
+const keySep = "\x1f"
+
+// recordKey builds the unique leveldb key for one record: kwPrefix + keyword +
+// keySep + offset. The record offset disambiguates same-headword entries
+// (homographs) that previously collided and overwrote each other when the key
+// was just the headword (issue #722 #1).
+func recordKey(keyword string, offset int64) string {
+	return strip(keyword) + keySep + strconv.FormatInt(offset, 10)
+}
 
 type MedictDBIndexer struct {
 	indexFileDirPath string
@@ -53,18 +67,23 @@ func (m *MedictDBIndexer) Close() error {
 	return m.lvdb.Close()
 }
 
+// Lookup returns the first record whose headword exactly matches keyword (the
+// first sense of a homograph). entry:// jumps carry no sense info, so
+// first-match is the only sensible default. Returns (nil, nil) when there is
+// no such keyword (mdictHolder.Lookup maps nil -> "not found").
 func (m *MedictDBIndexer) Lookup(keyword string) (*model.MdictKeyWordIndex, error) {
-	key := strip(keyword)
-	data, err := m.lvdb.Get(key)
+	kvs, err := m.lvdb.Prefix(strip(keyword) + keySep)
 	if err != nil {
 		return nil, err
 	}
-	indexData := new(model.MdictKeyWordIndex)
-	err = json.Unmarshal(data, indexData)
-	if err != nil {
-		return nil, err
+	for _, kv := range kvs {
+		r := new(model.MdictKeyWordIndex)
+		if err := json.Unmarshal(kv.Value, r); err != nil {
+			continue
+		}
+		return r, nil
 	}
-	return indexData, nil
+	return nil, nil
 }
 
 func (m *MedictDBIndexer) SetMeta(key, value string) error {
@@ -87,7 +106,7 @@ func (m *MedictDBIndexer) AddRecord(record *model.MdictKeyWordIndex) (resErr err
 		return err
 	}
 
-	key := strip(record.KeyWord)
+	key := recordKey(record.KeyWord, record.RecordLocateStartOffset)
 	err = m.lvdb.Put(key, data)
 	if err != nil {
 		return err
@@ -109,7 +128,7 @@ func (m *MedictDBIndexer) AddRecords(records []*model.MdictKeyWordIndex) (resErr
 		if err != nil {
 			return err
 		}
-		batch.Put([]byte(strip(r.KeyWord)), data)
+		batch.Put([]byte(recordKey(r.KeyWord, r.RecordLocateStartOffset)), data)
 	}
 	return m.lvdb.Write(batch)
 }

--- a/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
+++ b/pkg/service/mdict/mdict-idxer/leveldb_indexer_test.go
@@ -78,6 +78,48 @@ func TestLookup(t *testing.T) {
 	}
 }
 
+// TestDuplicateKeywords_NotCollapsed: same-headword entries (homographs) are
+// kept distinct via the offset-suffix key. Lookup returns the first sense;
+// Search surfaces all senses plus any longer matches (issue #722 #1).
+// On the legacy headword-only key this would collapse to one "bank".
+func TestDuplicateKeywords_NotCollapsed(t *testing.T) {
+	idxer, err := NewIndexer(filepath.Join(t.TempDir(), "dup"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idxer.AddRecords([]*model.MdictKeyWordIndex{
+		{KeyWord: "bank", RecordLocateStartOffset: 100}, // sense 1
+		{KeyWord: "bank", RecordLocateStartOffset: 200}, // sense 2 (same headword)
+		{KeyWord: "bankrupt", RecordLocateStartOffset: 300},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lookup returns the first sense of "bank" (offset 100).
+	got, err := idxer.Lookup("bank")
+	if err != nil {
+		t.Fatalf("Lookup(bank): %v", err)
+	}
+	if got == nil || got.KeyWord != "bank" || got.RecordLocateStartOffset != 100 {
+		t.Fatalf("Lookup(bank) = %+v, want first sense (offset 100)", got)
+	}
+
+	// Search("bank") surfaces BOTH senses (100, 200) plus the longer "bankrupt".
+	res, err := idxer.Search("bank")
+	if err != nil {
+		t.Fatalf("Search(bank): %v", err)
+	}
+	seen := map[int64]bool{}
+	for _, r := range res {
+		seen[r.RecordLocateStartOffset] = true
+	}
+	for _, want := range []int64{100, 200, 300} {
+		if !seen[want] {
+			t.Fatalf("Search(bank) missing offset %d (homograph collapsed?); got %v", want, seen)
+		}
+	}
+}
+
 // TestAllRecords: AllRecords returns every keyword record (and excludes the
 // PFMT#_ meta keys). Used by the holder to build the fuzzy BK-tree without
 // re-parsing the source dict (issue #722 #2).

--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -29,6 +29,11 @@ const (
 	fuzzyLimit     = 100
 )
 
+// indexSchemaVersion tags the .melev index format. Bumping it forces a one-time
+// rebuild on existing installs (and repairs legacy collision-broken indexes) —
+// issue #722 #1 (headword-only key -> offset-suffix key).
+const indexSchemaVersion = "2"
+
 // fuzzyEntry 包装 *MdictKeyWordIndex 用于 BK-tree 模糊搜索。
 // 不复用 MdictKeyWordIndex.Distance：后者基于 utils.StrToUnicode 转义串（每个 rune 展开为 6 字符的 \uXXXX），
 // 会把 1 个 rune 的差异放大成 6 个字符的 Levenshtein 距离，使 tolerance 语义失效。
@@ -161,19 +166,31 @@ func (mh *mdictHolder) Lookup(keyword string) ([]byte, error) {
 	return mh.rawdict.LocateByKeywordIndex(index)
 }
 
+// indexUpToDate reports whether the persisted .melev index is populated AND at
+// the current schema, so BuildIndex can skip the rebuild. Exposed as a helper
+// so the migration trigger is unit-testable without a source dict (issue #722 #1).
+func indexUpToDate(idx idxer.Indexer) bool {
+	v, err := idx.GetMeta("entries_num")
+	if err != nil || v == "" {
+		return false
+	}
+	sv, _ := idx.GetMeta("schema_version")
+	return sv == indexSchemaVersion
+}
+
 func (mh *mdictHolder) BuildIndex() error {
 	err := mh.rawdict.BuildIndex()
 	if err != nil {
 		return err
 	}
-	// has already built
-	value, err := mh.idxer.GetMeta("entries_num")
-	if err == nil && value != "" {
-		num, err1 := strconv.ParseInt(value, 10, 64)
-		if err1 == nil {
-			log.Infof("index has already built, entries number is %d", num)
-			return nil
+	// Skip the rebuild only if the index is populated AND at the current schema.
+	// A schema bump forces a one-time rebuild, which also repairs legacy indexes
+	// built with the collision-prone headword-only key (issue #722 #1).
+	if indexUpToDate(mh.idxer) {
+		if v, _ := mh.idxer.GetMeta("entries_num"); v != "" {
+			log.Infof("index already built (schema %s), entries: %s", indexSchemaVersion, v)
 		}
+		return nil
 	}
 
 	err = mh.idxer.SetMeta("Title", mh.rawdict.Title())
@@ -244,6 +261,9 @@ func (mh *mdictHolder) BuildIndex() error {
 	mh.bktreeDone = true
 	mh.lock.Unlock()
 
+	if err := mh.idxer.SetMeta("schema_version", indexSchemaVersion); err != nil {
+		return err
+	}
 	err = mh.idxer.SetMeta("entries_num", strconv.FormatInt(mh.rawdict.GetKeyWordEntriesSize(), 10))
 	return nil
 }

--- a/pkg/service/mdict/mdict_holder_fuzzy_test.go
+++ b/pkg/service/mdict/mdict_holder_fuzzy_test.go
@@ -69,6 +69,23 @@ func TestFuzzyFallback(t *testing.T) {
 	}
 }
 
+// TestIndexUpToDate: the schema migration trigger — a populated but old-schema
+// (or schema-less) index is NOT up to date, forcing a rebuild; current schema +
+// entries is up to date (issue #722 #1).
+func TestIndexUpToDate(t *testing.T) {
+	idx, err := idxer.NewIndexer(filepath.Join(t.TempDir(), "schema"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.False(t, indexUpToDate(idx), "empty index should not be up to date")
+
+	assert.NoError(t, idx.SetMeta("entries_num", "100"))
+	assert.False(t, indexUpToDate(idx), "old/missing schema should force rebuild")
+
+	assert.NoError(t, idx.SetMeta("schema_version", indexSchemaVersion))
+	assert.True(t, indexUpToDate(idx), "current schema + entries should skip rebuild")
+}
+
 // TestEnsureBkTree_FromIndexer: with bktreeDone=false (the .melev cache-hit
 // case), ensureBkTree builds the BK-tree from the leveldb index — not by
 // re-parsing the mdx — so fuzzy search still works (issue #722 #2).


### PR DESCRIPTION
> Issue: **#722**（Closes）。#722 最后一条：同名词条碰撞。

## 问题

key 原为 `PFKW#_<keyword>`，同名 headword（bank 名/动、同形异义词）`Put` 互相覆盖，**只留最后一个**，其余索引里查不到。

## 修复（offset-suffix key）

- key 改为 `PFKW#_<keyword>\x1f<record_start_offset>`（`\x1f`=Unit Separator，关键词里不会出现；offset 是每条记录的唯一位置，天然去重）。新增 `recordKey()`。
- `AddRecord`/`AddRecords` 用 `recordKey`。
- `Lookup` 改前缀扫 `PFKW#_<keyword>\x1f`，返回**首个义项**（`entry://` 跳转不携带义项信息，first-match 是唯一合理默认）；无结果返回 `(nil,nil)`（holder 已处理 nil → "not found"）。
- `Search` 不变（仍扫 `PFKW#_<typed>`），但语义升级：同名各义项都进 pending list（可挑选），更长词（bankrupt）照常命中 —— typeahead 行为天然正确。
- key 排序：`\x1f`(0x1f) < 任意可打印字符 → 同名各义项聚在一起、且排在更长词之前（bank* 在 bankrupt 之前）。

## 迁移（一次性）

- 新增 `indexSchemaVersion = "2"`；`BuildIndex` 幂等检查改为「`entries_num` 已设 **且** `schema_version` 匹配才跳过」，否则重建。提取 `indexUpToDate()` 助手便于单测。
- `BuildIndex` 末尾写入 `schema_version`。
- **用户可见后果**：升级后每个词典一次性重建（顺便修掉旧的碰撞损坏索引）。这是修正确性的必要代价，且只发生一次。

## 验证

```
TestDuplicateKeywords_NotCollapsed  两条同名 bank(100/200)+bankrupt，
                                     Lookup 返回首义项、Search 三条全命中
                                     （旧 headword key 下此测试 FAIL → red-green）
TestIndexUpToDate                    空/旧 schema → false（触发重建）；
                                     entries+schema → true
既有测试全过                          #723 King/ing、batch 等价、AllRecords、fuzzy 系列
go test -race ./pkg/service/... ./pkg/model/...   全绿
go build ./... + go vet ./...                     通过
```

## 至此 #722 全部完成

| 项 | PR |
|---|---|
| P0 strip TrimLeft→TrimPrefix | #723 |
| P1 移除连接池（panic 止血） | #724 |
| P1 Close 全链路 + shutdown | #725 |
| P2 batch + N+1；P3 死代码/日志/错误语义/并发 | #726 |
| #2 模糊搜索复用 leveldb 缓存 | #741 |
| **#1 同名碰撞 offset-suffix key + 迁移** | **本 PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)