### PR TITLE
fix(model): 词典列表按名称排序，不再按 MD5 (#740)

### DIFF
--- a/pkg/model/dict_def.go
+++ b/pkg/model/dict_def.go
@@ -17,6 +17,8 @@
 package model
 
 import (
+	"strings"
+
 	"github.com/creasty/go-levenshtein"
 	"github.com/terasum/medict/internal/libs/bktree"
 	"github.com/terasum/medict/internal/utils"
@@ -84,7 +86,9 @@ func (dlist DictList) Swap(i, j int) {
 }
 
 func (dlist DictList) Less(i, j int) bool {
-	return dlist[i].ID > dlist[j].ID
+	// 按名称大小写不敏感升序。旧实现按 ID（目录路径 MD5）倒序，顺序无意义且每次
+	// 新增词典都跳变（#740）。
+	return strings.ToLower(dlist[i].Name) < strings.ToLower(dlist[j].Name)
 }
 
 type PlainDictionaryInfo struct {

--- a/pkg/model/dict_def_test.go
+++ b/pkg/model/dict_def_test.go
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package model
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// TestDictList_SortByName: the list is ordered by Name, case-insensitive
+// ascending — not by ID (the MD5 of the dict dir), which was meaningless and
+// jumped on every new dict (#740).
+func TestDictList_SortByName(t *testing.T) {
+	list := DictList{
+		&PlainDictionaryItem{ID: "bb", Name: "OALD"},
+		&PlainDictionaryItem{ID: "aa", Name: "apple dict"},
+		&PlainDictionaryItem{ID: "cc", Name: "Cambridge"},
+	}
+	sort.Sort(list)
+
+	got := []string{list[0].Name, list[1].Name, list[2].Name}
+	want := []string{"apple dict", "Cambridge", "OALD"} // case-insensitive ascending
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Closes #740

## 问题

`DictList.Less`（`pkg/model/dict_def.go`）按 `PlainDictionaryItem.ID`（目录路径的 MD5）倒序排序。用户看到的词典顺序是按路径哈希的伪随机顺序，无意义且每次新增词典都跳变。

## 修复

改为按 `Name` 大小写不敏感升序。

## 验证

- `TestDictList_SortByName` 锁回归（`OALD / apple dict / Cambridge` → `apple dict, Cambridge, OALD`）
- `go build ./...` + `go vet ./pkg/model/` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)