### PR TITLE
chore: 清理死代码 Distance / MdictMeta / sanitizer (#734)

### DIFF
--- a/internal/static/handler/content_pipeline.go
+++ b/internal/static/handler/content_pipeline.go
@@ -19,7 +19,6 @@ package handler
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/sym01/htmlsanitizer"
 	"github.com/terasum/medict/internal/static/tmpl"
 
 	"github.com/terasum/medict/pkg/model"
@@ -43,13 +42,7 @@ var handler = &ContentPreHandlePipeline{
 	},
 }
 
-var sanitizer = htmlsanitizer.NewHTMLSanitizer()
 var base64encoder = base64.StdEncoding
-
-func init() {
-	sanitizer.RemoveTag("a")
-	sanitizer.RemoveTag("img")
-}
 
 func WrapDesc(dictid, title, desc string) string {
 	rep1 := &ReplacerImage{}
@@ -63,11 +56,6 @@ func WrapDesc(dictid, title, desc string) string {
 
 	rawHtml = base64encoder.EncodeToString([]byte(rawHtml))
 	return rawHtml
-	//sanitizedHTML, err := s.SanitizeString(rawHtml)
-	//if err != nil {
-	//	return "[sanitized failed]"
-	//}
-	//return sanitizedHTML
 }
 
 func WrapContent(dict *model.PlainDictionaryItem, keyEntry *model.MdictKeyWordIndex, definition string) ([]byte, error) {

--- a/pkg/model/dict_def.go
+++ b/pkg/model/dict_def.go
@@ -18,10 +18,6 @@ package model
 
 import (
 	"strings"
-
-	"github.com/creasty/go-levenshtein"
-	"github.com/terasum/medict/internal/libs/bktree"
-	"github.com/terasum/medict/internal/utils"
 )
 
 type DirDcitType string
@@ -141,24 +137,4 @@ type MdictKeyWordIndex struct {
 	RecordBlockDataDeCompressSize int64  `json:"record_block_data_decompress_size"`
 	KeyWordDataStartOffset        int64  `json:"keyword_data_start_offset"`
 	KeyWordDataEndOffset          int64  `json:"keyword_data_end_offset"`
-}
-
-// Distance calculates levenshtein distance.
-func (x *MdictKeyWordIndex) Distance(e bktree.Entry) int {
-	a := x.KeyWord
-	b := e.(*MdictKeyWordIndex).KeyWord
-	a = utils.StrToUnicode(a)
-	b = utils.StrToUnicode(b)
-
-	return levenshtein.Distance(a, b)
-}
-
-type MdictMeta struct {
-	ID               string `json:"id"`
-	Title            string `json:"title"`
-	Filepath         string `json:"filepath"`
-	Description      string `json:"description"`
-	IsRecordEncoding bool   `json:"is_record_encoding"`
-	IsUTF16          bool   `json:"is_utf_16"`
-	IsMDD            bool   `json:"is_mdd"`
 }


### PR DESCRIPTION
Closes #734

## 删除（已确认无引用）

- `model.MdictKeyWordIndex.Distance` —— 被 holder 的 `fuzzyEntry` 取代（#697/#723）后无调用方（BK-tree 现装 `*fuzzyEntry`），连同仅它使用的 `levenshtein`/`bktree`/`utils` 导入一并移除。
- `model.MdictMeta` —— 全仓零引用。
- `handler.sanitizer`（`htmlsanitizer`）—— 初始化并 `RemoveTag`，但 `WrapDesc` 实际应用是注释掉的（从未生效）。删变量、`init()`、注释残留、`htmlsanitizer` 导入。

## 关于 #734 其它项

- `StopChan` / `stopChannel`：**实际在用**（`app.shutdown` close、`BackServer.StopChan`），非死代码，**不删**（#734 误判）。
- `sqlite_indexer`：已在 #726 删除。

## 验证

```
go test -race ./pkg/... ./internal/...   全绿
go build ./... + go vet ./...            通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)