### PR TITLE
chore: 生产路径 fmt.Print* 收敛到 logger (#735)

### DIFF
--- a/internal/static/handler/content_pipeline.go
+++ b/internal/static/handler/content_pipeline.go
@@ -78,7 +78,7 @@ func handleContent(dict *model.PlainDictionaryItem, keyEntry *model.MdictKeyWord
 func handleResource(dictId string, keyWord string, resource []byte) []byte {
 	for _, han := range handler.handlers {
 		if han.Match(dictId, keyWord) {
-			fmt.Printf("resource handle matched [%s](%s)\n", keyWord, dictId)
+			log.Debugf("resource handle matched [%s](%s)", keyWord, dictId)
 			keyWord, resource = han.Replace(dictId, keyWord, resource)
 		}
 	}

--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"encoding/hex"
-	"fmt"
 	"github.com/terasum/medict/internal/static/handler"
 	"net/http"
 	"strconv"
@@ -46,7 +45,7 @@ func (dc *DictsController) HandleWordQueryReq(c *gin.Context) {
 	entry, err := convertKeyIndex(dictType, entryId, recordStart, recordEnd, keyWord, recordBlockDataStartOffset, recordBlockDataCompressSize, recordBlockDataDeCompressSize, keyWordDataStartOffset, keyWordDataEndOffset)
 	if err != nil {
 
-		fmt.Printf("NoRoute REQ ABORT: %s (%s:%s)\n", c.Request.RequestURI, "bad param convert", err.Error())
+		log.Errorf("NoRoute REQ ABORT: %s (bad param convert: %s)", c.Request.RequestURI, err.Error())
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}

--- a/pkg/service/support/filewalker.go
+++ b/pkg/service/support/filewalker.go
@@ -133,16 +133,16 @@ func innerWalkLevel2(level1Path, level2Path string) (*model.DirItem, error) {
 			item.MdictMdxAbsPath, _ = filepath.Abs(path)
 			item.MdictMdxFileName = utils.FileNameWithoutExt(path)
 			baseDir := utils.FileBaseDir(path)
-			fmt.Printf("path is %s, basedir is %s\n", path, baseDir)
+			log.Debugf("mdx path: %s, basedir: %s", path, baseDir)
 			pngPath := filepath.Join(baseDir, item.MdictMdxFileName+"."+"png")
-			fmt.Printf("pngpath: %s\n", pngPath)
+			log.Debugf("cover png candidate: %s", pngPath)
 			if utils.FileExists(pngPath) {
 				item.CoverImgPath = utils.FileAbs(pngPath)
 				item.CoverImgType = model.ImgTypePNG
 			}
 
 			jpgPath := filepath.Join(baseDir, item.MdictMdxFileName+"."+"jpg")
-			fmt.Printf("jpgpath: %s\n", pngPath)
+			log.Debugf("cover jpg candidate: %s", jpgPath)
 			if utils.FileExists(jpgPath) {
 				item.CoverImgPath = utils.FileAbs(jpgPath)
 				item.CoverImgType = model.ImgTypeJPG


### PR DESCRIPTION
Refs #735（热路径部分；启动期 [medict-init] 输出另案）

## 改动

热路径上残留的 `fmt.Printf` 转为各包 logger（go-logging）：

- `pkg/service/support/filewalker.go`：3 处 mdx/pngpath/jpgpath 调试输出 → `log.Debugf`；顺带修一个复制粘贴 bug（`jpgpath` 行原本误打 `pngPath`）。
- `internal/static/handler/content_pipeline.go`：`resource handle matched` → `log.Debugf`。
- `pkg/apis/dicts_controller.go`：`NoRoute REQ ABORT`（错误路径）→ `log.Errorf`；移除随之 unused 的 `fmt` 导入。

## 不在本 PR

- `internal/entry/app_loader.go` 与 `internal/config/config.go` 的 4 处 `[medict-init]` Printf：启动期（pre-Wails-logger）一次性输出，且这两个包尚无 logger，转 logger 涉及 bootstrap 日志方案，单独处理。
- vendored libs（go-mdict / art / bktree）的内部 print 不动。

## 验证

```
go test ./pkg/... ./internal/...   全绿
go build ./... + go vet ./...      通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)