### PR TITLE
refactor: innerResourceQuery 四路重试抽候选 key 循环 (#736)

### DIFF
--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -118,71 +118,58 @@ func (dc *DictsController) innerResourceQuery(c *gin.Context, key, dictId string
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}
-	log.Infof("innerResourceQuery(0) search key: [%s]", key)
+	log.Debugf("innerResourceQuery key: [%s]", key)
 
-	// 先从文件夹搜索
-	resultBytes, err := dc.ds.FindFromDir(dictId, key)
-	if err == nil {
-		log.Infof("innerResourceQuery search key hit dir: [%s]", key)
-		resultBytes, err = handler.WrapResource(dictId, key, resultBytes)
-		if err != nil {
-			wrapContentType(c, key, resultBytes)
+	// 1) dict folder first (css / cover image / etc. shipped alongside the .mdx).
+	if raw, err := dc.ds.FindFromDir(dictId, key); err == nil {
+		log.Debugf("resource hit dir: [%s]", key)
+		dc.serveResource(c, dictId, key, raw)
+		return
+	}
+
+	// 2) resource lookup across key variants (dicts may store paths with
+	//    backslashes or a leading separator).
+	for _, candidate := range resourceKeyCandidates(key) {
+		if raw, err := dc.ds.LookupResource(dictId, candidate); err == nil {
+			log.Debugf("resource hit: [%s]", candidate)
+			dc.serveResource(c, dictId, candidate, raw)
 			return
 		}
-		wrapContentType(c, key, resultBytes)
-		return
 	}
 
-	log.Infof("innerResourceQuery(1) search from resource [%s]", key)
-	// 再从文件资源中搜索
-	resultBytes, err = dc.ds.LookupResource(dictId, key)
-	if err == nil {
-		log.Infof("innerResourceQuery search key hit resource: [%s]", key)
-		resultBytes, err = handler.WrapResource(dictId, key, resultBytes)
-		if err != nil {
-			wrapContentType(c, key, resultBytes)
-			return
+	c.AbortWithStatus(http.StatusNotFound)
+}
+
+// resourceKeyCandidates returns the key variants to try for a resource lookup:
+// the key as-is, then "/" -> "\", then the same with a leading "\". Duplicates
+// are removed so a key without slashes isn't looked up three times (#736).
+func resourceKeyCandidates(key string) []string {
+	seen := make(map[string]struct{})
+	cands := make([]string, 0, 3)
+	add := func(s string) {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			cands = append(cands, s)
 		}
-
-		wrapContentType(c, key, resultBytes)
-		return
 	}
-
-	key = strings.ReplaceAll(key, "/", "\\")
-	log.Infof("innerResourceQuery(2) search from resource [%s]", key)
-	resultBytes, err = dc.ds.LookupResource(dictId, key)
-	if err == nil {
-		log.Infof("innerResourceQuery search key hit resource: [%s]", key)
-		resultBytes, err = handler.WrapResource(dictId, key, resultBytes)
-		if err != nil {
-			wrapContentType(c, key, resultBytes)
-			return
-		}
-
-		wrapContentType(c, key, resultBytes)
-		return
+	add(key)
+	backslash := strings.ReplaceAll(key, "/", "\\")
+	add(backslash)
+	if !strings.HasPrefix(backslash, "\\") {
+		add("\\" + backslash)
 	}
+	return cands
+}
 
-	// 补全路径重新搜索
-	if !strings.HasPrefix(key, "\\") {
-		key = "\\" + key
+// serveResource applies the resource pipeline and writes the response. WrapResource
+// currently never errors (it transforms in place); if it ever can, fall back to
+// the raw bytes rather than dropping the response (#736).
+func (dc *DictsController) serveResource(c *gin.Context, dictId, key string, raw []byte) {
+	out := raw
+	if wrapped, err := handler.WrapResource(dictId, key, raw); err == nil {
+		out = wrapped
 	}
-
-	log.Infof("innerResourceQuery(3) search from resource [%s]", key)
-
-	resultBytes, err = dc.ds.LookupResource(dictId, key)
-	if err != nil {
-		c.AbortWithStatus(http.StatusNotFound)
-		return
-	}
-
-	log.Infof("innerResourceQuery(4) search key hit resource with '\\' prefix: [%s]", key)
-	result, err := handler.WrapResource(dictId, key, resultBytes)
-	if err != nil {
-		wrapContentType(c, key, result)
-		return
-	}
-	wrapContentType(c, key, result)
+	wrapContentType(c, key, out)
 }
 
 func convertKeyIndex(dictType, entryId, recordStart, recordEnd, keyWord, recordBlockDataStartOffset, recordBlockDataCompressSize, recordBlockDataDeCompressSize, keyWordDataStartOffset, keyWordDataEndOffset string) (*model.KeyQueryIndex, error) {

--- a/pkg/apis/dicts_controller_test.go
+++ b/pkg/apis/dicts_controller_test.go
@@ -17,10 +17,31 @@
 package apis
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/terasum/medict/pkg/model"
 )
+
+// TestResourceKeyCandidates locks the candidate-key variants the resource
+// lookup tries (key as-is, "/" -> "\", leading "\"), with dedup (#736).
+func TestResourceKeyCandidates(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"css/x.css", []string{"css/x.css", "css\\x.css", "\\css\\x.css"}},
+		{"x.css", []string{"x.css", "\\x.css"}},    // no slash: backslash == key, deduped
+		{"/x.css", []string{"/x.css", "\\x.css"}},  // leading slash -> backslash already has leading "\"
+		{"\\x.css", []string{"\\x.css"}},           // already backslash + leading: single candidate
+	}
+	for _, tc := range cases {
+		got := resourceKeyCandidates(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("resourceKeyCandidates(%q) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+}
 
 // TestConvertKeyIndex locks the 8-param → struct conversion after the loop
 // refactor (#738): every param lands in the right field, empty params default


### PR DESCRIPTION
Closes #736

## 问题

原 `innerResourceQuery` 有 4 段几乎相同的 `FindFromDir`/`LookupResource` + `WrapResource` + `return` 复制粘贴（每段 ~6 行），改一处要改四处；且 `WrapResource` 失败分支返回的是可能已被 handler 改写的 `resultBytes`，语义可疑。

## 重写

- `resourceKeyCandidates(key)`：生成候选 key 列表（原值 → `/`\`\\`\` → 再加前导 `\`），**去重**避免无斜杠的 key 查 3 次。
- `innerResourceQuery`：先 `FindFromDir`（文件夹资源），再对候选 key 循环 `LookupResource`，命中即返；全部未命中 → 404。
- `serveResource`：统一 `WrapResource` + `wrapContentType`；`WrapResource` 当前永远返 nil error（原地改写），若将来失败则回退原 bytes。
- 顺带把 5 条 per-step 的 `log.Infof` 降为 `Debugf`（每次资源请求都打，噪音）。

## 验证

```
TestResourceKeyCandidates   锁候选生成 + 去重
go test -race ./pkg/... ./internal/...   全绿
go build ./... + go vet ./...            通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)