### PR TITLE
fix: 引入 model.ErrNotFound sentinel 区分「无结果」与真实错误 (#732)

### DIFF
--- a/pkg/model/errors.go
+++ b/pkg/model/errors.go
@@ -1,0 +1,24 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package model
+
+import "errors"
+
+// ErrNotFound is the sentinel for a normal "no such word / resource" miss, so
+// callers can tell a not-found apart from a real (I/O, parse) error via
+// errors.Is (issue #732) instead of string-matching error messages.
+var ErrNotFound = errors.New("not found")

--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -1,7 +1,7 @@
 package mdict
 
 import (
-	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -145,7 +145,7 @@ func (mh *mdictHolder) Lookup(keyword string) ([]byte, error) {
 	}
 
 	if entry == nil {
-		return nil, errors.New("not found")
+		return nil, model.ErrNotFound
 	}
 	index := &gomdict.MDictKeywordIndex{
 		KeywordEntry: gomdict.MDictKeywordEntry{
@@ -325,7 +325,7 @@ func (mh *mdictHolder) Search(keyword string) ([]*model.MdictKeyWordIndex, error
 	}
 	// 前缀为空（拼错/记不清词头）→ BK-tree 模糊兜底
 	if err := mh.ensureBkTree(); err != nil {
-		return nil, errors.New("result not found")
+		return nil, fmt.Errorf("build fuzzy index: %w", err)
 	}
 	// needle 必须是 *fuzzyEntry：Distance 依赖其类型断言
 	needle := &fuzzyEntry{&model.MdictKeyWordIndex{KeyWord: keyword}}

--- a/pkg/service/mdict/mdict_holder_fuzzy_test.go
+++ b/pkg/service/mdict/mdict_holder_fuzzy_test.go
@@ -69,6 +69,21 @@ func TestFuzzyFallback(t *testing.T) {
 	}
 }
 
+// TestLookup_MissReturnsErrNotFound: a keyword miss returns the sentinel
+// model.ErrNotFound (not a plain string error), so callers can errors.Is it
+// (issue #732).
+func TestLookup_MissReturnsErrNotFound(t *testing.T) {
+	idx, err := idxer.NewIndexer(filepath.Join(t.TempDir(), "miss"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mh := &mdictHolder{lock: &sync.Mutex{}, idxer: idx}
+	_, err = mh.Lookup("does-not-exist")
+	if !assert.True(t, errors.Is(err, model.ErrNotFound), "want ErrNotFound, got %v", err) {
+		t.FailNow()
+	}
+}
+
 // TestIndexUpToDate: the schema migration trigger — a populated but old-schema
 // (or schema-less) index is NOT up to date, forcing a rebuild; current schema +
 // entries is up to date (issue #722 #1).

--- a/pkg/service/mdict/mdict_svc.go
+++ b/pkg/service/mdict/mdict_svc.go
@@ -126,7 +126,7 @@ func (md *mdictSvcImpl) LookupResource(keyword string) ([]byte, error) {
 		if err != nil {
 			log.Infof("mdict.LookupResource failed, key [%s] not found, error: %s", keyword, err.Error())
 		}
-		return nil, fmt.Errorf("mdict resource not found: [%s]", keyword)
+		return nil, fmt.Errorf("mdict resource not found [%s]: %w", keyword, model.ErrNotFound)
 	}
 
 	return def, nil


### PR DESCRIPTION
Closes #732

## 问题

查询未命中返回 `errors.New("not found" / "result not found")`，与 I/O、解析错误共用同一 error 通道，调用方只能字符串匹配。

## 修复

- 新增 `model.ErrNotFound` sentinel（`pkg/model/errors.go`）。
- `mdictHolder.Lookup` 未命中（indexer 返 nil）→ `model.ErrNotFound`。
- `mdictHolder.Search` 的 `ensureBkTree` 失败路径：不再用 `"result not found"` **掩盖真实错误**，改为透传并 wrap（`fmt.Errorf("build fuzzy index: %w", err)`）。
- `mdictSvcImpl.LookupResource` 的 `"mdict resource not found"` → `fmt.Errorf` 包 `model.ErrNotFound`，调用方可 `errors.Is`。
- 移除 `mdict_holder.go` 随之 unused 的 `errors` 导入，引入 `fmt`。

> `indexer.Search` 与 holder.Search 的 BK-tree 兜底未命中已在 #726 改为 `(nil, nil)`；本 PR 补齐剩余的 error-as-not-found 点。

## 验证

```
TestLookup_MissReturnsErrNotFound   确认 errors.Is(err, model.ErrNotFound)
go test -race ./pkg/... ./internal/...   全绿
go build ./... + go vet ./...            通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)