### PR TITLE
fix(stardict): Lookup 未就绪返 ErrNotFound、LookupResource 返 ErrNotFound (#739)

### DIFF
--- a/pkg/service/stardict/stardict.go
+++ b/pkg/service/stardict/stardict.go
@@ -73,13 +73,22 @@ func (s *StarDict) DictType() model.DictType {
 	return model.DictTypeStarDict
 }
 
+// Lookup returns the definition HTML for keyword. The underlying lib renders a
+// "Nothing Found" page on a miss; a not-yet-built dictionary surfaces as
+// ErrNotFound rather than an empty body (#739).
 func (s *StarDict) Lookup(keyword string) ([]byte, error) {
-	w := s.SDict.Lookup(keyword)
-	return []byte(w), nil
+	if !s.ready {
+		return nil, model.ErrNotFound
+	}
+	return []byte(s.SDict.Lookup(keyword)), nil
 }
 
+// LookupResource: stardict resources (css/images/audio under the <name>.res
+// folder) are not loaded by the underlying lib today, so there is nothing to
+// serve. Return ErrNotFound so the request fails cleanly instead of an empty
+// 200 (#739). Full .res/ loading is a future feature.
 func (s *StarDict) LookupResource(keyword string) ([]byte, error) {
-	return []byte{}, nil
+	return nil, model.ErrNotFound
 }
 
 func (s *StarDict) Locate(entry *model.KeyQueryIndex) ([]byte, error) {

--- a/pkg/service/stardict/stardict_test.go
+++ b/pkg/service/stardict/stardict_test.go
@@ -2,11 +2,26 @@ package stardict
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/terasum/medict/pkg/model"
 )
+
+// TestStarDict_NotReadyAndResourceNotFound: a not-built StarDict surfaces
+// ErrNotFound from Lookup, and LookupResource returns ErrNotFound (stardict
+// resource loading isn't implemented — #739). No testdata required.
+func TestStarDict_NotReadyAndResourceNotFound(t *testing.T) {
+	s := &StarDict{ready: false}
+
+	if _, err := s.Lookup("anything"); !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("Lookup not-ready: want ErrNotFound, got %v", err)
+	}
+	if _, err := s.LookupResource("anything"); !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("LookupResource: want ErrNotFound, got %v", err)
+	}
+}
 
 func TestStarDict_Lookup(t *testing.T) {
 	// stardict testdata is not checked into the repo; skip when absent so CI


### PR DESCRIPTION
Closes #739

## 问题

stardict 的 `Lookup` 吞错误（不区分未命中），`LookupResource` 永远返回空 `[]byte{}`（stardict 的 css/图/音永远查不到、却静默返 200，渲染残缺）。

## 修复

- **`Lookup`**：`!ready` → `model.ErrNotFound`（不再返空 body）；命中/miss 仍走底层 `SDict.Lookup`（miss 时底层渲染 "Nothing Found" 页——受库能力限制）。
- **`LookupResource`** → `model.ErrNotFound`（不再返空 bytes 假装 200）。底层 go-stardict 库无资源加载能力；stardict 资源（`<name>.res/` 目录）加载是 **future feature**，在此之前让请求干净地 404 而非空 200。
- **`Close` no-op 保留**：与 mdict 同理（#731 调查），stardict 库不持有持久 fd/mmap，无需 Close。

## 不在本 PR

- `Description` 硬编码、miss 精确区分（受 go-stardict 库能力限制）。
- `<name>.res/` 资源加载（独立 feature，可另开 issue）。

## 验证

```
TestStarDict_NotReadyAndResourceNotFound   不需 testdata
go test -race ./pkg/... ./internal/...     全绿
go build ./... + go vet ./...              通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)