### PR TITLE
refactor(backserver): 词查询提为显式 GET 路由，NoRoute 降为资源兜底 (#728)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This is the single most important thing to understand. The Go side talks to the 
 
 2. **Embedded Gin HTTP server (data plane)** — dictionary definitions are rendered as full HTML inside an `<iframe>` in the webview. Those HTML payloads, plus their resources (css/js/images/fonts/audio), must be served same-origin, so a **Gin server is started on `localhost:0` (random port)** at app init. The frontend learns the port at runtime via the `App.ResourceServerAddr()` IPC call. URL root is `static.ContentRootUrl = "/__mdict"`. Word lookups use magic path `/__tcidem_query`.
 
-   Dispatch of HTTP requests happens entirely in a **`NoRoute` handler** (`back_server.go setUpRouters`): if the URI starts with `/__mdict/__tcidem_query` it is a word query (`HandleWordQueryReq`), otherwise it is a resource lookup (`HandleResourceQueryReq`). There are no explicit routes.
+   Word lookups go through an **explicit route** `GET /__mdict/__tcidem_query` (`HandleWordQueryReq`); everything else under the content root is a resource lookup handled by a `NoRoute` catch-all (`HandleResourceQueryReq`) (`back_server_inner.go setUpRouters`). Resource paths are arbitrary (css/images/fonts/...), so they stay a catch-all rather than enumerated routes.
 
 ### Dictionary abstraction
 `pkg/model/dict_interface.go` defines `GeneralDictionary` (`BuildIndex/Lookup/Locate/Search/LookupResource/DictType`). `mdict` (`pkg/service/mdict`) and `stardict` (`pkg/service/stardict`) implement it. `mdictSvcImpl` wraps one `mdx` holder plus N `mdd` holders (mdds are searched in order for resources).

--- a/pkg/backserver/back_server_inner.go
+++ b/pkg/backserver/back_server_inner.go
@@ -121,18 +121,18 @@ func cors() gin.HandlerFunc {
 
 func (bs *BackServer) setUpRouters() error {
 	bs.GinEngine.Use(cors())
-	bs.GinEngine.NoRoute(func(c *gin.Context) {
-		log.Infof("NoRoute REQ REQUEST URI: [%s]\n", c.Request.RequestURI)
 
-		if strings.HasPrefix(c.Request.RequestURI, static.ContentRootUrl+static.WordQueryMagicPath) {
-			log.Infof("NoRoute REQ REQUEST URI(word): [%s]\n", c.Request.RequestURI)
-			bs.DictCon.HandleWordQueryReq(c)
-			return
-		} else {
-			log.Infof("NoRoute REQ REQUEST URI(resource): [%s]\n", c.Request.RequestURI)
-			bs.DictCon.HandleResourceQueryReq(c)
-			return
-		}
+	// Word lookup: an explicit route (previously a string-HasPrefix branch
+	// inside NoRoute — issue #728). Discoverable, middleware-able, structured
+	// errors via the handler instead of catch-all dispatch.
+	bs.GinEngine.GET(static.ContentRootUrl+static.WordQueryMagicPath, bs.DictCon.HandleWordQueryReq)
+
+	// Everything else is a resource lookup. Resource paths are arbitrary
+	// (css / images / fonts / ... under the content root), so they stay a
+	// catch-all rather than enumerated routes.
+	bs.GinEngine.NoRoute(func(c *gin.Context) {
+		log.Debugf("resource request: %s", c.Request.RequestURI)
+		bs.DictCon.HandleResourceQueryReq(c)
 	})
 	return nil
 }


### PR DESCRIPTION
Closes #728

## 问题

`setUpRouters` 未注册任何显式路由，词查询靠 `NoRoute` + `strings.HasPrefix` 字符串分发——反 RESTful、不可发现、无法挂中间件、CLAUDE.md 标记的 sharp edge。

## 修复

- 注册**显式路由**：`GET /__mdict/__tcidem_query` → `HandleWordQueryReq`。
- `NoRoute` 降为**纯资源兜底**（资源路径任意，无法枚举为路由，catch-all 保留），去掉里面的 `HasPrefix` 词查询分支。
- 顺带把 2 条 per-request 的 `log.Infof` 降为 1 条 `Debugf`（噪音）。
- 更新 CLAUDE.md 的「无显式路由」sharp-edge 说明。

> `convertKeyIndex` 的 8 个 offset query 参数抽 helper 已在 #738 完成。

## 验证

```
go test -race ./pkg/... ./internal/...   全绿
go build ./... + go vet ./...            通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)