### PR TITLE
chore: 精简启动/查询阶段的 per-Locate/Lookup 日志

### DIFF
--- a/internal/libs/go-mdict/mdict.go
+++ b/internal/libs/go-mdict/mdict.go
@@ -134,7 +134,7 @@ func (mdict *Mdict) Lookup(word string) ([]byte, error) {
 	word = strings.TrimSpace(word)
 	for id, keyBlockEntry := range mdict.keyBlockData.keyEntries {
 		if keyBlockEntry.KeyWord == word {
-			log.Infof("mdict.Lookup hit entries[%d/%d] key:(%s), entry-key:(%s), equals(%v)", id, len(mdict.keyBlockData.keyEntries), word, keyBlockEntry.KeyWord, keyBlockEntry.KeyWord == word)
+			log.Debugf("mdict.Lookup hit entries[%d/%d] key:(%s), entry-key:(%s), equals(%v)", id, len(mdict.keyBlockData.keyEntries), word, keyBlockEntry.KeyWord, keyBlockEntry.KeyWord == word)
 			return mdict.LocateByKeywordEntry(keyBlockEntry)
 		}
 	}

--- a/internal/libs/go-mdict/mdict_base.go
+++ b/internal/libs/go-mdict/mdict_base.go
@@ -887,7 +887,6 @@ func (mdict *MdictBase) keywordEntryToIndex1(item *MDictKeywordEntry) (*MDictKey
 	}
 
 	if recordBlockInfo == nil {
-		fmt.Printf("record block info is nil, current keyBlockEntry: %+v, last recordBlockInfo: %+v\n", item, mdict.recordBlockInfo.recordInfoList[len(mdict.recordBlockInfo.recordInfoList)-1])
 		return nil, errors.New("key-item record info not found")
 	}
 
@@ -924,7 +923,7 @@ func (mdict *MdictBase) locateByKeywordIndex(index *MDictKeywordIndex) ([]byte, 
 }
 
 func locateDefByKWIndex(index *MDictKeywordIndex, filePath string, isRecordEncrypted, isMdd, isUtf16 bool) ([]byte, error) {
-	log.Infof("locateDefByKWIndex invoked %+v, filepath %s, isRecordEncrypted %v, isMdd %v, isUTF16 %v", index, filePath, isRecordEncrypted, isMdd, isUtf16)
+	log.Debugf("locateDefByKWIndex invoked %+v, filepath %s, isRecordEncrypted %v, isMdd %v, isUTF16 %v", index, filePath, isRecordEncrypted, isMdd, isUtf16)
 	file, err := os.Open(filePath)
 	if err != nil {
 		log.Errorf("open file err %s", err.Error())
@@ -1008,12 +1007,12 @@ func locateDefByKWIndex(index *MDictKeywordIndex, filePath string, isRecordEncry
 	data := recordBlock[start:end]
 
 	if isMdd {
-		log.Errorf("return mdd data")
+		log.Debugf("return mdd data")
 		return data, nil
 	}
 
 	if isUtf16 {
-		log.Infof("keyword %s, data len %d", index.KeywordEntry.KeyWord, len(data))
+		log.Debugf("keyword %s, data len %d", index.KeywordEntry.KeyWord, len(data))
 		datastr, err1 := decodeLittleEndianUtf16(data)
 		if err1 != nil {
 			return nil, err
@@ -1051,7 +1050,6 @@ func (mdict *MdictBase) locateByKeywordEntry(item *MDictKeywordEntry) ([]byte, e
 	}
 
 	if recordBlockInfo == nil {
-		fmt.Printf("record block info is nil, current keyBlockEntry: %+v, last recordBlockInfo: %+v\n", item, mdict.recordBlockInfo.recordInfoList[len(mdict.recordBlockInfo.recordInfoList)-1])
 		return nil, errors.New("key-item record info not found")
 	}
 

--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -119,7 +119,7 @@ func (mh *mdictHolder) Locate(entry *model.MdictKeyWordIndex) ([]byte, error) {
 		},
 	}
 
-	log.Infof("holder %+v", index.RecordBlock)
+	log.Debugf("holder %+v", index.RecordBlock)
 
 	def, err := mh.rawdict.LocateByKeywordIndex(index)
 	if err != nil {


### PR DESCRIPTION
Refs #735

按反馈精简「indexing/启动过程」日志对启动性能的影响。调查结论：go-mdict 的 **BuildIndex 逐条路径本就无日志**；噪音来自启动后前端查询反复触发的 per-Locate/Lookup INFO + 残留 `fmt.Printf`。

## 改动

- `mdict.go:137` Lookup hit、`mdict_base.go:927` locateDefByKWIndex、`mdict_base.go:1016` keyword+datalen：`Infof → Debugf`。
- `mdict_base.go:1011` "return mdd data"：`Errorf → Debugf`（非错误）。
- `mdict_base.go:890/1054` 的 `fmt.Printf("record block info is nil…")`：删除（紧随其后已 `return error`，冗余）。
- `mdict_holder.go:122` `log.Infof("holder %+v", RecordBlock)`：per-Locate 格式化大结构，`Infof → Debugf`。

保留 per-dict 的 BuildIndex 摘要（`mdict_holder.go:191`，每词典一次，INFO 有用）。

## 验证

```
go test ./internal/libs/go-mdict/ ./pkg/service/mdict/   全绿
go build ./... + go vet ./...                            通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)