### PR TITLE
refactor(service): DictService 单例 → 构造注入 (#727)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This is the single most important thing to understand. The Go side talks to the 
 ### Dictionary abstraction
 `pkg/model/dict_interface.go` defines `GeneralDictionary` (`BuildIndex/Lookup/Locate/Search/LookupResource/DictType`). `mdict` (`pkg/service/mdict`) and `stardict` (`pkg/service/stardict`) implement it. `mdictSvcImpl` wraps one `mdx` holder plus N `mdd` holders (mdds are searched in order for resources).
 
-`pkg/service/dicts_service.go` `DictService` is a **package-global singleton** (`singltonInstanceDictService`) holding `map[string]*model.DictionaryItem`. The map key is the MD5 of the dictionary directory path (see `pkg/service/dict_item.go` `NewByDirItem`). Every method takes `dictLock`. Lookup/Search/Locate all **require `BuildIndex` to have run first** or they return `"dictionary not ready"`.
+`pkg/service/dicts_service.go` `DictService` holds `map[string]*model.DictionaryItem`; it's constructed by `App` via `NewDictService` and injected into `BackServer.SetUp` (no longer a package-global singleton — #727). The map key is the MD5 of the dictionary directory path (see `pkg/service/dict_item.go` `NewByDirItem`). Every method takes `dictLock`. Lookup/Search/Locate all **require `BuildIndex` to have run first** or they return `"dictionary not ready"`.
 
 ### Dictionaries are directories, auto-scanned
 A dictionary = one directory under `BaseDictDir` (config `medict.toml`, default per-OS app-data `.../medict/dicts`). `pkg/service/support/filewalker.go` walks the dir; `DirItem` (`pkg/model/dict_def.go`) captures mdx/mdd or stardict (dz/ifo/idx) files plus optional `_cover.jpg`, `_mdict.dtype`/`_stardict.dtype`. Type is auto-detected by file presence.

--- a/app.go
+++ b/app.go
@@ -39,6 +39,7 @@ type App struct {
 	errorChannel chan error
 	stopChannel  chan int
 	bs           *backserver.BackServer
+	dictSvc      *service.DictService
 	// initErr 捕获 appInit 同步阶段的错误，由 errorChanListen 在 Wails
 	// startup() 生命周期里确定性地产出，避免向无缓冲 channel 塞值带来的时序赌博。
 	initErr error
@@ -62,13 +63,18 @@ func (b *App) appInit() error {
 		return err
 	}
 
+	dictsSvc, err := service.NewDictService(conf)
+	if err != nil {
+		return err
+	}
+	b.dictSvc = dictsSvc
+
 	bs, err := backserver.NewStaticServer(conf)
 	if err != nil {
 		return err
 	}
 
-	err = bs.SetUp()
-	if err != nil {
+	if err := bs.SetUp(dictsSvc); err != nil {
 		return err
 	}
 	// assign backend server
@@ -96,8 +102,8 @@ func (b *App) shutdown(ctx context.Context) {
 	close(b.errorChannel)
 	b.bs.GracefulStop()
 	// Release per-dictionary resources (leveldb handles, etc.).
-	if ds := service.GetDictService(); ds != nil {
-		if err := ds.Close(); err != nil {
+	if b.dictSvc != nil {
+		if err := b.dictSvc.Close(); err != nil {
 			log.Errorf("shutdown: close dictionaries failed: %s", err.Error())
 		}
 	}

--- a/pkg/backserver/back_server.go
+++ b/pkg/backserver/back_server.go
@@ -62,18 +62,13 @@ func NewStaticServer(conf *config.Config) (*BackServer, error) {
 	return bs, nil
 }
 
-func (bs *BackServer) SetUp() error {
-	dictsSvc, err := service.NewDictService(bs.Config)
-	if err != nil {
-		return fmt.Errorf("back_server setup failed, err: %s", err.Error())
-	}
-
-	dictCon := apis.NewDictsController(dictsSvc)
-	bs.DictCon = dictCon
+// SetUp wires the injected DictService into the controller and registers
+// handlers/routes. The DictService is owned by App and passed in (issue #727).
+func (bs *BackServer) SetUp(dictsSvc *service.DictService) error {
+	bs.DictCon = apis.NewDictsController(dictsSvc)
 	bs.setupHandlers()
 
-	err = bs.setUpRouters()
-	if err != nil {
+	if err := bs.setUpRouters(); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/service/dicts_service.go
+++ b/pkg/service/dicts_service.go
@@ -32,32 +32,21 @@ import (
 	"github.com/terasum/medict/pkg/service/support"
 )
 
-var (
-	singltonInstanceDictService *DictService
-	singletonOnce               sync.Once
-)
-
 type DictService struct {
 	config   *config.Config
 	dicts    map[string]*model.DictionaryItem
 	dictLock *sync.Mutex
 }
 
+// NewDictService constructs a DictService. It is a plain constructor — no
+// process-wide singleton — so the caller (App) owns the instance and injects
+// it where needed (issue #727).
 func NewDictService(config *config.Config) (*DictService, error) {
-	singletonOnce.Do(func() {
-		singltonInstanceDictService = &DictService{
-			config:   config,
-			dicts:    make(map[string]*model.DictionaryItem),
-			dictLock: new(sync.Mutex),
-		}
-	})
-	return singltonInstanceDictService, nil
-}
-
-// GetDictService returns the process-wide DictService singleton, or nil if
-// NewDictService has not run yet (e.g. app init failed before SetUp).
-func GetDictService() *DictService {
-	return singltonInstanceDictService
+	return &DictService{
+		config:   config,
+		dicts:    make(map[string]*model.DictionaryItem),
+		dictLock: new(sync.Mutex),
+	}, nil
 }
 
 // Close releases resources held by all loaded dictionaries (e.g. leveldb


### PR DESCRIPTION
Closes #727

## 问题

`DictService` 用 `singletonOnce` + 进程级 `singltonInstanceDictService` + `GetDictService()`：`NewDictService` 是伪构造函数（第二次调用被 `sync.Once` 吞掉、新 config 无效），构造注入与全局取用并存易漂移，且无法注入 mock 做单测。

## 修复

去掉全局可变状态，`App` 持有 `*DictService` 并注入：

- `dicts_service.go`：`NewDictService` 改为真正构造器（每次返回新实例）；删 `GetDictService` 与全局变量。
- `back_server.go`：`SetUp(dictsSvc *service.DictService)` 接收注入，不再自建。
- `app.go`：`App` 加 `dictSvc` 字段；`appInit` 加载 config 后 `NewDictService(conf)` → 注入 `bs.SetUp(dictsSvc)` → 持有引用；`shutdown` 直接 `b.dictSvc.Close()`。
- `CLAUDE.md`：更新 singleton 描述。

## 验证

```
go build ./... + go vet ./... + go test ./pkg/service/... ./internal/...   通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)