### PR TITLE
refactor(ipc): typed IPC 替代字符串 Dispatch（#729）

### DIFF
--- a/app.go
+++ b/app.go
@@ -109,9 +109,18 @@ func (b *App) shutdown(ctx context.Context) {
 	}
 }
 
-func (b *App) Dispatch(apiName string, args map[string]interface{}) *model.Resp {
-	log.Infof("[wails] IPC request dispatch [%s] | args: %v\n", apiName, args)
-	return b.bs.DispatchIPCReq(apiName, args)
+// Typed IPC handlers (issue #729): each frontend call maps to a typed App
+// method, replacing the old string-dispatched Dispatch / handlerMap.
+func (b *App) InitDicts() *model.Resp { return b.bs.DictCon.InitDicts() }
+
+func (b *App) GetAllDicts() *model.Resp { return b.bs.DictCon.GetAllDicts() }
+
+func (b *App) SearchWord(dictId, word string) *model.Resp {
+	return b.bs.DictCon.SearchWord(dictId, word)
+}
+
+func (b *App) BuildIndexByDictId(dictid string) *model.Resp {
+	return b.bs.DictCon.BuildIndexByDictId(dictid)
 }
 
 func (b *App) ResourceServerAddr() string {

--- a/frontend/src/apis/apis.ts
+++ b/frontend/src/apis/apis.ts
@@ -16,19 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Dispatch, ResourceServerAddr, OpenFinder, BaseDictDir } from '../../wailsjs/go/main/App';
-
-import { model } from '../../wailsjs/go/models';
-
-function objectToPathParams(obj) {
-  const params = [];
-  for (const key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      params.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`);
-    }
-  }
-  return params.join('&');
-}
+import { ResourceServerAddr, OpenFinder, BaseDictDir } from '../../wailsjs/go/main/App';
 
 export const StaticDictServerURL = function (): Promise<string> {
   if (window['go']) {
@@ -51,21 +39,5 @@ export const BaseDictDirectory = function():Promise<string>{
     return BaseDictDir()
   } else {
     return Promise.resolve("internal error")
-  }
-}
-
-
-
-export async function requestBackend(apiName, data): Promise<model.Resp> {
-  if (window['go']) {
-    console.log(`[dicts-api] ipc call, dispatch [${apiName}] event, args:`, data)
-    return Dispatch(apiName, data);
-  } else {
-    return Promise.resolve({
-      data:"",
-      err: "browser not support or system not initialzd yet",
-      code: 500,
-    })
-
   }
 }

--- a/frontend/src/apis/dicts-api.ts
+++ b/frontend/src/apis/dicts-api.ts
@@ -16,87 +16,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Typed IPC wrappers (issue #729): each call goes to a typed App method
+// (wailsjs binding) instead of the old string-dispatched requestBackend/Dispatch.
 import { IDict } from './types';
 import { model } from './model';
-import {requestBackend} from '@/apis/apis';
+import * as App from '../../wailsjs/go/main/App';
 
-
-export const GetDictCover = async function(dict_id: string, cover_name:string): Promise<model.Resp> {
-try{
-        let resp = await requestBackend("GetDictCover", {dict_id, cover_name})
-        console.log("[dicts-api] GetDictCover: ", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api] GetDictCover: " ,error)
-        return Promise.reject(error)
-    }
+export const InitDicts = async function (): Promise<model.Resp> {
+    const resp = await App.InitDicts();
+    return resp.data as unknown as model.Resp;
 }
-
-export const InitDicts = async function(): Promise<model.Resp> {
-    try{
-        let resp = await requestBackend("InitDicts", {})
-        console.log("[dicts-api] InitDicts: ", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api] InitDicts: " ,error)
-        return Promise.reject(error)
-    }
-}
-
 
 export const GetAllDicts = async function (): Promise<Array<IDict>> {
-    try{
-        let resp = await requestBackend("GetAllDicts", {})
-        console.log("[dicts-api] GetAllDicts: ", resp)
-        return resp.data as unknown as Array<IDict>
-    } catch (error) {
-        console.error("[dicts-api] GetAllDicts: " ,error)
-        return Promise.reject(error)
-    }
+    const resp = await App.GetAllDicts();
+    return resp.data as unknown as Array<IDict>;
 }
 
 // BuildIndex
 export const BuildIndex = async function (dictid: string): Promise<model.Resp> {
-    try{
-        let resp = await requestBackend("BuildIndexByDictId", {dictid: dictid})
-        console.log("[dicts-api] BuildIndex: ", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api] BuildIndex: " ,error)
-        return Promise.reject(error)
-    }
+    const resp = await App.BuildIndexByDictId(dictid);
+    return resp.data as unknown as model.Resp;
 }
 
-
-export const LookupWord = async function (dictid:string, word: string) : Promise<model.Resp> {
-    try{
-        let resp = await requestBackend("LookupWord", {dict_id:dictid, word:word})
-        console.log("[dicts-api]", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api]" ,error)
-        return Promise.reject(error)
-    }
-}
-
-export const SearchWord = async function(dictid:string, word: string) :Promise<model.Resp> {
-    try{
-        let resp = await requestBackend("SearchWord", {dict_id: dictid, word: word})
-        console.log("[dicts-api]", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api]" ,error)
-        return Promise.reject(error)
-    }
-}
-
-export const LocateWord = async function(dictid:string, keyBlockEntry: model.KeyBlockEntry): Promise<model.Resp> {
-    try{
-        let resp = await requestBackend("LocateWord", {dict_id: dictid, key_block_entry: keyBlockEntry})
-        console.log("[dicts-api]", resp)
-        return resp.data as unknown as model.Resp
-    } catch (error) {
-        console.error("[dicts-api]" ,error)
-        return Promise.reject(error)
-    }
+export const SearchWord = async function (dictid: string, word: string): Promise<model.Resp> {
+    const resp = await App.SearchWord(dictid, word);
+    return resp.data as unknown as model.Resp;
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -4,8 +4,14 @@ import {model} from '../models';
 
 export function BaseDictDir():Promise<string>;
 
-export function Dispatch(arg1:string,arg2:{[key: string]: any}):Promise<model.Resp>;
+export function BuildIndexByDictId(arg1:string):Promise<model.Resp>;
+
+export function GetAllDicts():Promise<model.Resp>;
+
+export function InitDicts():Promise<model.Resp>;
 
 export function OpenFinder(arg1:string):Promise<void>;
 
 export function ResourceServerAddr():Promise<string>;
+
+export function SearchWord(arg1:string,arg2:string):Promise<model.Resp>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,8 +6,16 @@ export function BaseDictDir() {
   return window['go']['main']['App']['BaseDictDir']();
 }
 
-export function Dispatch(arg1, arg2) {
-  return window['go']['main']['App']['Dispatch'](arg1, arg2);
+export function BuildIndexByDictId(arg1) {
+  return window['go']['main']['App']['BuildIndexByDictId'](arg1);
+}
+
+export function GetAllDicts() {
+  return window['go']['main']['App']['GetAllDicts']();
+}
+
+export function InitDicts() {
+  return window['go']['main']['App']['InitDicts']();
 }
 
 export function OpenFinder(arg1) {
@@ -16,4 +24,8 @@ export function OpenFinder(arg1) {
 
 export function ResourceServerAddr() {
   return window['go']['main']['App']['ResourceServerAddr']();
+}
+
+export function SearchWord(arg1, arg2) {
+  return window['go']['main']['App']['SearchWord'](arg1, arg2);
 }

--- a/pkg/apis/dicts_handler.go
+++ b/pkg/apis/dicts_handler.go
@@ -2,55 +2,42 @@ package apis
 
 import (
 	"errors"
+
 	"github.com/terasum/medict/pkg/model"
 )
 
-// GetAllDicts
-func (dc *DictsController) GetAllDicts(args map[string]interface{}) *model.Resp {
-	dicts := dc.ds.Dicts()
-	return model.BuildSuccess(dicts)
+// GetAllDicts returns the list of loaded dictionaries.
+func (dc *DictsController) GetAllDicts() *model.Resp {
+	return model.BuildSuccess(dc.ds.Dicts())
 }
 
-// InitDicts 初始化词典
-func (dc *DictsController) InitDicts(args map[string]interface{}) *model.Resp {
-	err := dc.ds.InitDicts()
-	if err != nil {
+// InitDicts scans the dict directory and loads dictionaries.
+func (dc *DictsController) InitDicts() *model.Resp {
+	if err := dc.ds.InitDicts(); err != nil {
 		return model.BuildError(err, model.InnerSysErrCode)
 	}
 	return model.BuildSuccess(nil)
 }
 
-// buildIndex
-func (dc *DictsController) BuildIndexByDictId(args map[string]interface{}) *model.Resp {
-	if id, ok := args["dictid"]; !ok {
+// BuildIndexByDictId builds the keyword index for one dictionary.
+func (dc *DictsController) BuildIndexByDictId(dictid string) *model.Resp {
+	if dictid == "" {
 		return model.BuildError(errors.New("build index failed, dictid is empty"), model.InnerSysErrCode)
-	} else {
-		log.Infof("[wails] building dictionary index, dict id is %s", id)
-		dict := dc.ds.GetDictById(id.(string))
-		if err := dict.MainDict.BuildIndex(); err != nil {
-			log.Infof("[wails] building dictionary index, dictionary path is %s", dict.MainDict.Name())
-			log.Infof("[wails] building dictionary index failed, err %s", err.Error())
-			return model.BuildError(err, model.InnerSysErrCode)
-		} else {
-			log.Infof("[wails] building dictionary index success, id: %s", dict.MainDict.Name())
-			return model.BuildSuccess(dict.MainDict.Name())
-		}
 	}
+	log.Infof("[wails] building dictionary index, dict id is %s", dictid)
+	dict := dc.ds.GetDictById(dictid)
+	if err := dict.MainDict.BuildIndex(); err != nil {
+		log.Infof("[wails] building dictionary index, dictionary path is %s", dict.MainDict.Name())
+		log.Infof("[wails] building dictionary index failed, err %s", err.Error())
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	log.Infof("[wails] building dictionary index success, id: %s", dict.MainDict.Name())
+	return model.BuildSuccess(dict.MainDict.Name())
 }
 
-// SearchWord
-func (dc *DictsController) SearchWord(args map[string]interface{}) *model.Resp {
-	dictId, ok := args["dict_id"]
-	if !ok {
-		return model.BuildError(errors.New("dict_id not found"), model.BadParamErrCode)
-	}
-
-	word, ok := args["word"]
-	if !ok {
-		return model.BuildError(errors.New("dict_id not found"), model.BadParamErrCode)
-	}
-
-	entries, err := dc.ds.Search(dictId.(string), word.(string))
+// SearchWord returns the matching keyword entries for a dictionary.
+func (dc *DictsController) SearchWord(dictId, word string) *model.Resp {
+	entries, err := dc.ds.Search(dictId, word)
 	if err != nil {
 		return model.BuildError(err, model.InnerSysErrCode)
 	}

--- a/pkg/backserver/back_server.go
+++ b/pkg/backserver/back_server.go
@@ -18,18 +18,15 @@ package backserver
 
 import (
 	"context"
-	"fmt"
 	"github.com/terasum/medict/pkg/apis"
 	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/terasum/medict/internal/config"
 	"github.com/terasum/medict/internal/static"
-	"github.com/terasum/medict/pkg/model"
 	"github.com/terasum/medict/pkg/service"
 )
 
@@ -48,8 +45,6 @@ type BackServer struct {
 
 	GinEngine *gin.Engine
 	DictCon   *apis.DictsController
-
-	handlerMap sync.Map
 }
 
 func NewStaticServer(conf *config.Config) (*BackServer, error) {
@@ -66,7 +61,6 @@ func NewStaticServer(conf *config.Config) (*BackServer, error) {
 // handlers/routes. The DictService is owned by App and passed in (issue #727).
 func (bs *BackServer) SetUp(dictsSvc *service.DictService) error {
 	bs.DictCon = apis.NewDictsController(dictsSvc)
-	bs.setupHandlers()
 
 	if err := bs.setUpRouters(); err != nil {
 		return err
@@ -84,17 +78,6 @@ func (bs *BackServer) Start() {
 	} else {
 		bs.startStaticServer("localhost:0")
 	}
-}
-
-func (bs *BackServer) DispatchIPCReq(apiName string, args map[string]interface{}) *model.Resp {
-	if handler, ok := bs.handlerMap.Load(apiName); ok {
-		handleFun, ok2 := handler.(func(map[string]interface{}) *model.Resp)
-		if !ok2 {
-			return model.BuildError(fmt.Errorf("[%s] Dispatch failed,type assertion of func( map) *model.Resp failed", apiName), model.InnerSysErrCode)
-		}
-		return handleFun(args)
-	}
-	return model.BuildError(fmt.Errorf("[%s] Dispatch failed, not found handler", apiName), model.BadReqCode)
 }
 
 func (bs *BackServer) GracefulStop() {

--- a/pkg/backserver/back_server_inner.go
+++ b/pkg/backserver/back_server_inner.go
@@ -136,10 +136,3 @@ func (bs *BackServer) setUpRouters() error {
 	})
 	return nil
 }
-
-func (bs *BackServer) setupHandlers() {
-	bs.handlerMap.Store("InitDicts", bs.DictCon.InitDicts)
-	bs.handlerMap.Store("GetAllDicts", bs.DictCon.GetAllDicts)
-	bs.handlerMap.Store("SearchWord", bs.DictCon.SearchWord)
-	bs.handlerMap.Store("BuildIndexByDictId", bs.DictCon.BuildIndexByDictId)
-}


### PR DESCRIPTION
Closes #729

## 问题

`App.Dispatch(apiName, args)` + `handlerMap`（string→`interface{}`）+ 运行时类型断言：apiName 拼写错误编译期发现不了、参数 `map[string]interface{}` 弱类型、丢编译期类型安全。

## 修复（全量原生 typed binding）

每个 handler 提升为 typed `App` 方法（模式同现有 `ResourceServerAddr`/`OpenFinder`/`BaseDictDir` 这些已用的原生绑定）：

**后端**
- `app.go`：新增 `InitDicts()`/`GetAllDicts()`/`SearchWord(dictId, word)`/`BuildIndexByDictId(dictid)`，各委托 `b.bs.DictCon.<Method>`；删 `Dispatch`。
- `pkg/apis/dicts_handler.go`：4 个 handler 由 `func(map[string]interface{}) *Resp` 改为 typed 签名（去掉 `args["..."]` 提取与类型断言）。
- `pkg/backserver`：删 `handlerMap` 字段、`setupHandlers`、`DispatchIPCReq`。

**前端**
- `wailsjs/go/main/App.js` + `App.d.ts`：加 4 个 typed 绑定条目（稳定格式，`wails dev/build` 幂等重生成），删 `Dispatch`。
- `dicts-api.ts`：4 个实际在用的调用改调 typed App 方法（保留 `resp.data` 提取契约不变）；**删 3 个无后端、无前端引用的死函数** `GetDictCover`/`LookupWord`/`LocateWord`。
- `apis.ts`：删随之 dead 的 `requestBackend`/`objectToPathParams`/`Dispatch` 导入/`model` 导入。

> `model.Resp.data` 仍是 `any`，故 `dicts-api` 里 `resp.data` 的 `as unknown as` 强转保留 —— 那是 **#702**（model.Resp.data 类型化）范畴，非本 #729（dispatch typed）范畴。

## 验证

```
go build/vet/test   通过
bun run build        ✓ built（wailsjs 条目 + dicts-api/apis 改动自洽）
```

> 端到端（`wails dev` 实际查词/建索引/列表）需本机 wails 验证（CI 不跑 wails）；wailsjs 重生成会确认手写条目无漂移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)