### PR TITLE
chore: 启动期 [medict-init] 日志接 logger（#735 收尾）

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,14 +17,16 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/op/go-logging"
 	"github.com/spf13/viper"
 	"github.com/terasum/medict/internal/utils"
 )
+
+var log = logging.MustGetLogger("config")
 
 type ConfigStruct struct {
 	BaseDictDir string `toml:"BaseDictDir"`
@@ -65,7 +67,7 @@ func (c *Config) Write() error {
 func (c *Config) EnsureDictsDir() (string, error) {
 	dirPath := c.BaseDictDir
 	defer func() {
-		fmt.Printf("[medict-init]: ensure app config directory: %s\n", dirPath)
+		log.Infof("[medict-init]: ensure app config directory: %s", dirPath)
 	}()
 
 	if dirPath == "" {

--- a/internal/entry/app_loader.go
+++ b/internal/entry/app_loader.go
@@ -18,13 +18,15 @@ package entry
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/op/go-logging"
 	"github.com/terasum/medict/internal/config"
 	"github.com/terasum/medict/internal/utils"
 )
+
+var log = logging.MustGetLogger("entry")
 
 var cfg *config.Config
 
@@ -34,7 +36,7 @@ func defaultConfigPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("[medict-init]: default config dir: %s\n", appConfigDir)
+	log.Infof("[medict-init]: default config dir: %s", appConfigDir)
 
 	configFile := filepath.Join(appConfigDir, "medict.toml")
 	if _, err = os.Stat(configFile); errors.Is(err, os.ErrNotExist) {
@@ -44,7 +46,7 @@ func defaultConfigPath() (string, error) {
 		}
 	}
 
-	fmt.Printf("[medict-init]: default config file: %s\n", configFile)
+	log.Infof("[medict-init]: default config file: %s", configFile)
 	return configFile, nil
 }
 
@@ -64,7 +66,7 @@ func loadConfig() (*config.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("[medict-init]: config dicts dir: %s\n", cfg.BaseDictDir)
+	log.Infof("[medict-init]: config dicts dir: %s", cfg.BaseDictDir)
 	return cfg, nil
 }
 


### PR DESCRIPTION
Closes #735

`internal/entry` 与 `internal/config` 此前无 logger，4 处 `[medict-init]` 启动信息用 `fmt.Printf` 直写 stdout。改为各包 go-logging logger（默认 backend 在 pre-Wails 阶段即生效），统一日志体系。

- `app_loader.go`：加 `var log = logging.MustGetLogger("entry")`，3 处 `Printf → Infof`；删随之 unused 的 `fmt` 导入。
- `config.go`：加 `var log = logging.MustGetLogger("config")`，1 处 `Printf → Infof`；删 `fmt` 导入。

至此 #735 的 `fmt.Print*` 残留全部清完（热路径 #745、convertKeyIndex 噪音 #738、本 PR 收启动期）。

```
go build/vet/test   通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)