### PR TITLE
chore(frontend): 开启 TypeScript strict，vue-tsc 零错误（#702）

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -127,13 +127,13 @@ function listenStoreChange(store: any) {
       args, // 传递给 action 的参数数组
       after, // 在 action 返回或解决后的钩子
       onError, // action 抛出或拒绝的钩子
-    }) => {
+    }: any) => {
       let startTime = Date.now();
       console.debug(`[store-action] {${name}} triggered started, args: {${args}}`);
 
       // 这将在 action 成功并完全运行后触发。
       // 它等待着任何返回的 promise
-      after((result) => {
+      after((result: any) => {
         console.debug(
           `[store-action] {${name}} triggered success, after ${
             Date.now() - startTime
@@ -142,7 +142,7 @@ function listenStoreChange(store: any) {
       });
 
       // 如果 action 抛出或返回一个拒绝的 promise，这将触发
-      onError((error) => {
+      onError((error: any) => {
         console.warn(
           `[store-action] {${name}} trigger faild, after ${
             Date.now() - startTime
@@ -154,7 +154,7 @@ function listenStoreChange(store: any) {
   return unscribe;
 }
 
-let unscribeDictQueryStore = null;
+let unscribeDictQueryStore: (() => void) | null = null;
 const dictQueryStore = useDictQueryStore();
 onMounted(()=>{
   unscribeDictQueryStore = listenStoreChange(dictQueryStore);

--- a/frontend/src/apis/apis.ts
+++ b/frontend/src/apis/apis.ts
@@ -19,7 +19,7 @@
 import { ResourceServerAddr, OpenFinder, BaseDictDir } from '../../wailsjs/go/main/App';
 
 export const StaticDictServerURL = function (): Promise<string> {
-  if (window['go']) {
+  if ((window as any)['go']) {
     return ResourceServerAddr();
   } else {
     return Promise.resolve("http://localhost:1")
@@ -27,7 +27,7 @@ export const StaticDictServerURL = function (): Promise<string> {
 };
 
 export const OpenDirOrFile = function(filepath :string):Promise<void>{
-  if (window['go']) {
+  if ((window as any)['go']) {
     return OpenFinder(filepath)
   } else {
     return Promise.resolve()
@@ -35,7 +35,7 @@ export const OpenDirOrFile = function(filepath :string):Promise<void>{
 }
 
 export const BaseDictDirectory = function():Promise<string>{
-  if (window['go']) {
+  if ((window as any)['go']) {
     return BaseDictDir()
   } else {
     return Promise.resolve("internal error")

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
+  export default component;
+}

--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -114,10 +114,10 @@ let searchWordRequestId = 0;
 export const useDictQueryStore = defineStore('dictQuery', {
   state: () => ({
     dictApiBaseURL: '',
-    queryPendingList: [],
+    queryPendingList: [] as any[],
     mainContent: btoa(DefaultContentTemplpate),
     mainContentURL: '',
-    selectDict: { id: '', name: '', path: '' },
+    selectDict: { id: '', name: '', path: '' } as any,
     inputSearchWord: '',
 
     historyStack: new HistoryStack(),
@@ -174,7 +174,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
       });
     },
     // 更新 pending list
-    updatePendingList(wordList) {
+    updatePendingList(wordList: any) {
       console.log(`[app-event](store-action), updatePendingList`, wordList);
 
       this.queryPendingList = wordList;
@@ -186,7 +186,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
     },
     // 更新main iframe内容
-    updateMainContent(content) {
+    updateMainContent(content: string) {
       // 防止循环嵌入 frame
       if (this.dictApiBaseURL === "") {
         return;
@@ -198,7 +198,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
     },
     // 更新 main iframe url
-    updateMainContentURL(url) {
+    updateMainContentURL(url: string) {
       // 防止循环嵌入 frame
       if (this.dictApiBaseURL === "") {
         return;
@@ -209,7 +209,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
     },
     // 更新选中的词典
-    updateSelectDict(dictItem) {
+    updateSelectDict(dictItem: any) {
       this.selectDict = dictItem;
       if (this.inputSearchWord && this.inputSearchWord.trim() != '') {
         this.searchWord(this.inputSearchWord);
@@ -278,12 +278,12 @@ export const useDictQueryStore = defineStore('dictQuery', {
           });
       }, 1000);
     },
-    updateBaseURL(url) {
+    updateBaseURL(url: string) {
       console.log(url);
       this.dictApiBaseURL = url;
     },
     // 定位单词并返回释义
-    locateWord(entry_idx, skipPushHistory: boolean = false) {
+    locateWord(entry_idx: number, skipPushHistory: boolean = false) {
       if (this.dictApiBaseURL === '' || this.selectDict.id === '') {
         console.log(
           "app or dictionary has not ready, skipped"
@@ -343,7 +343,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
 
       this.historyStack.push(qurier);
     },
-    pushHistoryByEntryIDx(entry_idx){
+    pushHistoryByEntryIDx(entry_idx: number){
       if (entry_idx < 0 || entry_idx >= this.queryPendingList.length) {
         return;
       }
@@ -380,7 +380,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
 
       SearchWord(locateQuerier.dict_id, locateQuerier.keyword ).then((res) => {
         console.info('[store-action]{backHistory} success', locateQuerier.keyword, res);
-        this.queryPendingList = res;
+        this.queryPendingList = res as any;
       }).catch((err) => {
         console.info('[store-action]{backHistory} failed', err);
       });
@@ -401,7 +401,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
 
       SearchWord(locateQuerier.dict_id, locateQuerier.keyword ).then((res) => {
         console.info('[store-action]{forwardHistory} success', locateQuerier.keyword, res);
-        this.queryPendingList = res;
+        this.queryPendingList = res as any;
       }).catch((err) => {
         console.info('[store-action]{forwardHistory} failed', err);
       });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -130,15 +130,15 @@ export function makeID(length: number) {
 // debounce 防抖函数
 // desc: 减少函数多次调用问题
 // borrowed from David Walsh : https://davidwalsh.name/javascript-debounce-function
-export function debounce(func, wait, immediate) {
-  let timeout;
+export function debounce(func: any, wait: number, immediate?: boolean) {
+  let timeout: any;
 
-  return function () {
+  return function (this: any) {
     const context = this;
 
     const args = arguments;
 
-    const later = function () {
+    const later = function (this: any) {
       timeout = null;
       if (!immediate) func.apply(context, args);
     };

--- a/frontend/src/view/debug/DebugResourceSearch.vue
+++ b/frontend/src/view/debug/DebugResourceSearch.vue
@@ -51,8 +51,8 @@ import { StaticDictServerURL } from '@/apis/apis';
 import { useDictQueryStore } from '@/store/dict';
 
 const dictQueryStore = useDictQueryStore();
-let selectedDict = ref(null);
-let optionDicts = reactive([]);
+let selectedDict = ref<any>(null);
+let optionDicts = reactive<{ label: string; value: string }[]>([]);
 let staticServerUrl = ref('');
 let resourceInputValue = ref('');
 let result = reactive({

--- a/frontend/src/view/docs/index.vue
+++ b/frontend/src/view/docs/index.vue
@@ -95,7 +95,7 @@ const uiStore = useUIStore();
 uiStore.updateCurrentTab("docs");
 
 
-const routerMap = {
+const routerMap: Record<number, string> = {
   0: "/docs/index",
   1: "/docs/select_and_use",
   2: "/docs/faq",

--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -222,7 +222,7 @@ onUnmounted(() => {
 // utils function
 ///----------------------------
 
-function b64DecodeUnicode(str) {
+function b64DecodeUnicode(str: string) {
   return decodeURIComponent(
     atob(str)
       .split('')

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,7 +3,11 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ESNext",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "jsx": "preserve",
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -12,10 +16,17 @@
     "isolatedModules": true,
     "baseUrl": "./",
     "paths": {
-      "@/*": ["src/*"],
-      "$/*": ["wails/*"]
+      "@/*": [
+        "src/*"
+      ],
+      "$/*": [
+        "wails/*"
+      ]
     },
-    "types": ["vite/client"]
+    "types": [
+      "vite/client"
+    ],
+    "strict": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Closes #702

tsconfig 开 `strict: true`；修完全部 66 个 strict 错误（`*.vue` shim 修 12 + 代码修 54），`bun run typecheck`（vue-tsc --noEmit，strict）**零错误**。

## 修复明细
- **新增 `src/env.d.ts`**：`declare module '*.vue'` shim（修 TS7016 `.vue` 导入无声明，12 个）。
- **store/dict/index.ts**：`queryPendingList [] as any[]`（原推断 `never[]`，是 ~20 个 `Property X on never` 的根因）、`selectDict as any`、各 action 参数加类型、back/forward 的 `res` 赋值加 cast。
- **App.vue**：`$onAction` 回调解构 `: any`、`after`/`onError` 回调参数、`unscribeDictQueryStore` 显式类型。
- **utils/index.ts**：`debounce` 参数/`timeout`/`this` 加类型。
- **apis.ts**：`window['go']` → `(window as any)['go']`（×3）。
- **docs/index.vue**：`routerMap` 加 `Record<number,string>`（修数字索引对象字面量）。
- **DebugResourceSearch.vue**：`optionDicts`/`selectedDict` `reactive`/`ref` 加类型（原 `never[]`）。
- **MainContentFrame.vue**：`b64DecodeUnicode(str: string)`。

## 验证
```
bun run typecheck   # vue-tsc --noEmit，strict，零错误
bun run build       ✓
```
CI 的 Typecheck 步现在在 strict 下把关。

> 说明：现有动态代码（store/api 层）用 `any` 占位（数据是 runtime 动态的 Resp.data）；strict 的价值在于**拦截新增**代码的类型错误，已落地 CI gate。

🤖 Generated with [Claude Code](https://claude.com/claude-code)