### PR TITLE
fix(apis): @@@LINK 支持多目标 + 链式重定向（#260）

### DIFF
--- a/pkg/apis/dicts_controller.go
+++ b/pkg/apis/dicts_controller.go
@@ -1,7 +1,6 @@
 package apis
 
 import (
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -24,6 +23,59 @@ type DictsController struct {
 
 func NewDictsController(svc *service.DictService) *DictsController {
 	return &DictsController{svc: svc}
+}
+
+// linkTargets returns the @@@LINK target words in an MDict definition, handling
+// multiple targets and "</>"/newline sub-record separators. Empty if def is not
+// a redirect. (Extracted for unit testing — #260.)
+func linkTargets(def string) []string {
+	normalized := strings.ReplaceAll(strings.TrimSpace(def), "</>", "\n")
+	var targets []string
+	for _, line := range strings.Split(normalized, "\n") {
+		line = strings.TrimSpace(line)
+		if t := strings.TrimPrefix(line, "@@@LINK="); t != line && t != "" {
+			targets = append(targets, strings.TrimSpace(t))
+		}
+	}
+	return targets
+}
+
+// resolveLinkRedirects resolves MDict @@@LINK cross-references in a definition.
+// A def may contain one or more "@@@LINK=<word>" lines (sub-records separated
+// by "</>" or newlines); each target is located recursively (depth- and
+// cycle-guarded), and multi-target defs concatenate. Fixes #260: the old code
+// followed only the first target of a single hop, so multi-target redirects
+// showed blank and chained redirects (A→B→C) stopped at the first hop or leaked
+// the raw "@@@LINK=" text.
+func (dc *DictsController) resolveLinkRedirects(dictId, def string, depth int, visited map[string]bool) string {
+	const maxDepth = 8
+	if depth > maxDepth {
+		return def
+	}
+	targets := linkTargets(def)
+	if len(targets) == 0 {
+		return def // not a redirect; show original
+	}
+	var resolved []string
+	for _, target := range targets {
+		if visited[target] {
+			continue // cycle guard
+		}
+		visited[target] = true
+		result, err := dc.svc.Search(dictId, target)
+		if err != nil || len(result) == 0 {
+			continue
+		}
+		targetDef, err := dc.svc.Locate(dictId, result[0])
+		if err != nil {
+			continue
+		}
+		resolved = append(resolved, dc.resolveLinkRedirects(dictId, targetDef, depth+1, visited))
+	}
+	if len(resolved) == 0 {
+		return def // nothing resolved; show original rather than blank
+	}
+	return strings.Join(resolved, "\n")
 }
 
 func (dc *DictsController) HandleWordQueryReq(c *gin.Context) {
@@ -57,25 +109,8 @@ func (dc *DictsController) HandleWordQueryReq(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
-	// handle @@@Link=${word}
-	def = strings.TrimSpace(def)
-
-	if strings.HasPrefix(def, "@@@LINK=") {
-		log.Infof("search @@@LINK=>[%s], hex:[%s]", def, hex.EncodeToString([]byte(def)))
-		newWord := strings.TrimPrefix(def, "@@@LINK=")
-		newWord = strings.TrimRight(newWord, "\r\n\000")
-		result, err1 := dc.svc.Search(dictId, newWord)
-		if err1 == nil && len(result) > 0 {
-			newEntry := result[0]
-			def1, err2 := dc.svc.Locate(dictId, newEntry)
-			// handle link jump
-			if err2 == nil {
-				def = def1
-			} else {
-				log.Errorf("search @@@link jump failed %s, %v", def, err2)
-			}
-		}
-	}
+	// handle @@@Link=${word} redirects (single, multi-target, and chained)
+	def = dc.resolveLinkRedirects(dictId, strings.TrimSpace(def), 0, map[string]bool{})
 
 	dict, ok := dc.svc.GetDictPlain(dictId)
 	if !ok {

--- a/pkg/apis/dicts_controller_test.go
+++ b/pkg/apis/dicts_controller_test.go
@@ -43,6 +43,34 @@ func TestResourceKeyCandidates(t *testing.T) {
 	}
 }
 
+// TestLinkTargets covers MDict @@@LINK target parsing — single, multi-target
+// (newline and "</>" sub-record separators), trailing whitespace/CR, and the
+// non-redirect case. This is the core of the #260 multi-target/chain fix.
+func TestLinkTargets(t *testing.T) {
+	cases := []struct {
+		name string
+		def  string
+		want []string
+	}{
+		{"single", "@@@LINK=foo", []string{"foo"}},
+		{"multi-newline", "@@@LINK=foo\n@@@LINK=bar", []string{"foo", "bar"}},
+		{"multi-record-sep", "@@@LINK=滋</>@@@LINK=滋", []string{"滋", "滋"}},
+		{"trailing-crlf", "@@@LINK=foo\r\n", []string{"foo"}},
+		{"trim-spaces", "@@@LINK=  foo  ", []string{"foo"}},
+		{"not-a-redirect", "<p>real definition</p>", nil},
+		{"empty-link-ignored", "@@@LINK=", nil},
+	}
+	for _, tc := range cases {
+		got := linkTargets(tc.def)
+		if len(got) == 0 && len(tc.want) == 0 {
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("%s: linkTargets(%q) = %#v, want %#v", tc.name, tc.def, got, tc.want)
+		}
+	}
+}
+
 // TestConvertKeyIndex locks the 8-param → struct conversion after the loop
 // refactor (#738): every param lands in the right field, empty params default
 // to 0, a bad integer errors, and dictType maps to IndexType.


### PR DESCRIPTION
Refs #260（@@@LINK 部分）

## 问题

`HandleWordQueryReq` 的 `@@@LINK` 处理只取第一条目标、单跳、且只解析首行：
- **多目标重定向空白**（`滋` → `滋` 与 `滋`）：`newWord` 把整段（含第二条 `@@@LINK`）当查询词 → 查不到 → 空白。
- **链式重定向断**（`见→見→見b`）：停在第一跳；直接查中间词 `見` 时把 `@@@LINK=見b` 当文本显示。

## 修复

新增 `resolveLinkRedirects`：递归解析每条 `@@@LINK` 目标（按 `</>`/换行拆分子记录）、链式跟随（`maxDepth` + `visited` 环检测）、多目标拼接。抽 `linkTargets` 纯函数便于单测。解析不到任何目标时返回原文（不再空白）。

## 验证
```
TestLinkTargets   覆盖 单/多目标(换行与</>)/尾随 CR/LF/空格/非重定向
go build/vet/test 通过
```
> 递归跟随依赖真实词典，端到端需带 `@@@LINK` 的词典验证（链式 + 多目标）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)