### PR TITLE
feat: Ctrl+/- 与滚轮缩放 + 双击选词查词（#260 缩放、#258）

### DIFF
--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -92,7 +92,7 @@
       ></span>
      </div>
     </div>
-    <div id="app-content-main-iframe-wrapper">
+    <div id="app-content-main-iframe-wrapper" ref="wrapperRef">
       <iframe
         ref="iframeRef"
         class="app-content-main-iframe"
@@ -122,9 +122,11 @@ const TOP_WIN_MSG_ZOOM_IN =  '__Medict_TOP_WIN_MSG_EVTP_ZOOM_IN';
 const TOP_WIN_MSG_REFRESH = '__Medict_TOP_WIN_MSG_EVTP_REFRESH';
 const TOP_WIN_MSG_SETUP =  '__Medict_TOP_WIN_MSG__EVTY_SETUP__';
 const INNER_FRAME_MSG_ENTRY_JUMP = '__Medict_INNER_FRAME_MSG_EVTP_ENTRY_JUMP';
+const INNER_FRAME_MSG_DBLCLICK_LOOKUP = '__Medict_INNER_FRAME_MSG_EVTP_DBLCLICK_LOOKUP';
 
 // 声明式 iframe：通过 Vue 响应式驱动 src，避免命令式 createElement / 手动设 .src
 const iframeRef = ref<HTMLIFrameElement | null>(null);
+const wrapperRef = ref<HTMLDivElement | null>(null);
 
 // iframe 的 src：优先使用 mainContentURL（释义查询 URL），否则用 mainContent 构造 data URL。
 // 由 Vue 响应式驱动，store 中 mainContent / mainContentURL 变化时自动更新。
@@ -166,6 +168,16 @@ function onInnerFrameMessage(e: MessageEvent) {
 
       break;
     }
+    // 双击选词查词（#258）
+    case INNER_FRAME_MSG_DBLCLICK_LOOKUP: {
+      let keyWord = (e.data.word || '').split('#')[0];
+      if (keyWord) {
+        dictQueryStore.updateInputSearchWord(keyWord);
+        dictQueryStore.searchWord(keyWord);
+        dictQueryStore.pushHistoryByEntryIDx(0);
+      }
+      break;
+    }
   }
 }
 
@@ -196,6 +208,18 @@ function zoomIn() {
   );
 }
 
+// Ctrl/Cmd + =/- 与 Ctrl/Cmd + 滚轮缩放词典 iframe（#260）
+function onZoomKey(e: KeyboardEvent) {
+  if (!(e.ctrlKey || e.metaKey)) return;
+  if (e.key === '=' || e.key === '+') { e.preventDefault(); zoomIn(); }
+  else if (e.key === '-' || e.key === '_') { e.preventDefault(); zoomOut(); }
+}
+function onIframeWheel(e: WheelEvent) {
+  if (!(e.ctrlKey || e.metaKey)) return;
+  e.preventDefault();
+  if (e.deltaY < 0) zoomIn(); else zoomOut();
+}
+
 // devtools
 function showInspector() {
   const wailsEvent = "wails:showInspector";
@@ -209,6 +233,8 @@ function showInspector() {
 
 onMounted(() => {
   window.addEventListener('message', onInnerFrameMessage);
+  window.addEventListener('keydown', onZoomKey);
+  wrapperRef.value?.addEventListener('wheel', onIframeWheel, { passive: false });
   setTimeout(function () {
     dictQueryStore.setUpAPIBaseURL();
   }, 1000);
@@ -216,6 +242,8 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener('message', onInnerFrameMessage);
+  window.removeEventListener('keydown', onZoomKey);
+  wrapperRef.value?.removeEventListener('wheel', onIframeWheel);
 })
 
 ///----------------------------

--- a/internal/static/tmpl/dict_def_templ.go
+++ b/internal/static/tmpl/dict_def_templ.go
@@ -95,6 +95,14 @@ function __medict_entry_jump(word, dict_id) {
 		e.preventDefault();
 		__medict_entry_jump(href.slice(ENTRY_PREFIX.length), __MEDICT_DICT_ID__);
 	});
+	// Double-click → look up the browser-selected word (#258). The native
+	// selection (CJK word-boundary aware) fires on dblclick.
+	document.addEventListener("dblclick", function(e) {
+		var sel = window.getSelection ? String(window.getSelection()).trim() : "";
+		if (sel) {
+			window.top.postMessage({"evtype":"__Medict_INNER_FRAME_MSG_EVTP_DBLCLICK_LOOKUP", "word": sel}, __TOPFRAME_SECURE_ORIGIN__);
+		}
+	});
 }());
 
 </script>


### PR DESCRIPTION
Refs #260（缩放部分）、Closes #258

## 缩放快捷键（#260，原先只有按钮）
`MainContentFrame` 加 `Ctrl/Cmd + =/-` keydown 与 `Ctrl/Cmd + 滚轮` wheel 监听，复用现有 `zoomIn/zoomOut`（postMessage 给 iframe 调字号）；`onMounted/onUnmounted` 成对挂载/卸载；wrapper div 加 `ref` 挂 wheel。

## 双击选词查词（#258，对齐 macOS Dictionary）
- 释义 iframe 模板加 `document dblclick`：取浏览器原生选区（CJK 词边界感知）→ postMessage 给 top 窗口（仿 `entry://` 跳转机制）。
- `MainContentFrame` 加 `INNER_FRAME_MSG_DBLCLICK_LOOKUP` 处理 → `searchWord`。

## 验证
```
go build/vet                         通过
bun run typecheck (strict)           零错误
bun run build                        ✓
```
> 端到端（实际双击/缩放交互）需 `wails dev` 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)