### PR TITLE
fix(mdict): Name() 用 TrimSuffix 替代 TrimRight cutset，修词典名截断（#259）

### DIFF
--- a/internal/libs/go-mdict/mdict.go
+++ b/internal/libs/go-mdict/mdict.go
@@ -93,11 +93,11 @@ func (mdict *Mdict) BuildIndex() error {
 
 func (mdict *Mdict) Name() string {
 	_, rawpath := filepath.Split(mdict.filePath)
-	rawpath = strings.TrimRight(rawpath, ".mdx")
-	if len(rawpath) > 0 {
-		return rawpath
-	}
-	return rawpath
+	// TrimSuffix, not TrimRight: TrimRight treats ".mdx" as a *cutset* and would
+	// eat trailing m/d/x chars off the name (e.g. "mad.mdx" -> "ma", "foox.mdd"
+	// -> "foo"). TrimSuffix of the actual extension is correct for both mdx/mdd.
+	// (#259)
+	return strings.TrimSuffix(rawpath, filepath.Ext(rawpath))
 }
 
 func (mdict *Mdict) Title() string {

--- a/internal/libs/go-mdict/mdict_test.go
+++ b/internal/libs/go-mdict/mdict_test.go
@@ -174,3 +174,24 @@ func TestMdict_LookupMdd6(t *testing.T) {
 
 	file.Close()
 }
+
+// TestMdict_Name: regression for #259 — Name() used TrimRight(cutset) which
+// ate trailing m/d/x chars ("mad.mdx" -> "ma"). TrimSuffix of the extension is
+// correct for both .mdx and .mdd.
+func TestMdict_Name(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/dicts/mad.mdx", "mad"},
+		{"/dicts/OALD10.mdx", "OALD10"},
+		{"/dicts/foox.mdd", "foox"},
+		{"/dicts/标题词典.mdx", "标题词典"},
+	}
+	for _, tc := range cases {
+		m := &Mdict{MdictBase: &MdictBase{filePath: tc.path}}
+		if got := m.Name(); got != tc.want {
+			t.Fatalf("Name(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #259

## 问题

`mdict.Name()` 用 `strings.TrimRight(rawpath, ".mdx")`——第二参数是 **cutset**（字符集合），会吃掉文件名尾部所有属于 `{.,m,d,x}` 的字符：`mad.mdx`→`ma`、`foox.mdd`→`foo`，词典显示名被截坏（与 #723 的 `strip` TrimLeft bug 同类）。

## 修复

改为 `strings.TrimSuffix(rawpath, filepath.Ext(rawpath))`，按真实扩展名（`.mdx`/`.mdd`）去后缀，名字正确。

> #259 的"添加词典繁琐/需手填名称"诉求已被 v3 自动扫描 + 自动命名满足（docs 明说"只需放到扫描目录"；前端无手填 UI）。本 PR 修的是自动命名里的这个截断 bug。

## 验证
```
TestMdict_Name   覆盖 mad.mdx / OALD10.mdx / foox.mdd / CJK
go build/vet/test   通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)