### PR TITLE
feat(setting): 调试工具移入设置子页面（#643 遗留）

### DIFF
--- a/frontend/src/view/setting/index.vue
+++ b/frontend/src/view/setting/index.vue
@@ -63,6 +63,10 @@
                     <span class="icon icon-rocket"></span>
                     <a> 插件设置</a>
                   </span>
+                  <span class="nav-group-item" @click='changeTab("/debug")'>
+                    <span class="icon icon-bug"></span>
+                    <a> 调试工具</a>
+                  </span>
                 </nav>
                 <nav class="nav-group">
                   <h5 class="nav-group-title">关于信息</h5>


### PR DESCRIPTION
SettingWindow 导航加「调试工具」入口（`/debug`），与已有的「插件设置」同组。插件/调试从顶级 tab 移除后（#643 PR），现在都可通过设置页面访问。

```
bun run typecheck (strict)   零错误
bun run build                ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)