### PR TITLE
style: header UI 重设计——缩 logo、搜索栏 flex:1、收紧按钮、去 fake-title-bar

### DIFF
--- a/frontend/src/components/layout/AppFunctions.vue
+++ b/frontend/src/components/layout/AppFunctions.vue
@@ -18,22 +18,23 @@
     // border-bottom: 1px solid #dcdcdc;
 
     .header-nav-functions {
-      max-width: 306px;
+      max-width: 280px;
       height: auto;
       padding: 0;
       margin: 0;
-      margin-left: 20px;
-      margin-top: 12px;
+      margin-left: 8px;
+      margin-top: 0;
       display: flex;
+      align-items: center;
       flex-direction: row;
       .fn-box-active {
         background-color: $theme-function-box-active-color;
       }
       .fn-box {
-        width: 52px;
-        height: 44px;
-        margin-top: -6px;
-        padding-top: 6px;
+        width: 46px;
+        height: 40px;
+        margin-top: 0;
+        padding-top: 4px;
         cursor: pointer;
         border-radius: 4px;
         margin-left: 2px;
@@ -46,8 +47,8 @@
         }
 
         .fn-box-icon {
-          width: 20px;
-          height: 20px;
+          width: 18px;
+          height: 18px;
           display: block;
           font-size: 16px;
           line-height: 18px;

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -64,7 +64,7 @@ import AppFunctions from './AppFunctions.vue';
   .app-header-logo {
     display: flex;
     height: calc($layout-sidebar-logo-height - 1px);
-    width: 120px;
+    width: 72px;
     .logo {
       display: flex;
       flex-direction: row;
@@ -76,26 +76,25 @@ import AppFunctions from './AppFunctions.vue';
       }
       h1 {
         color: $theme-logo-font-color;
-        font-style: italic;
-        font-size: 24px;
+        font-size: 16px;
+        font-weight: 600;
       }
     }
   }
   .app-header-func-box{
     display: flex;
     justify-content: space-between;
-    width: calc(100% - 120px);
+    align-items: center;
+    width: calc(100% - 72px);
     .app-header-func-solt{
       display: flex;
       flex-direction: row;
       align-items: center;
-      justify-content: center;
-      min-width: 120px;
-      height: 54px;
+      flex: 1;
+      height: 100%;
       padding: 0;
       margin: 0;
-      min-width: 174px;
-      margin-left: 40px;
+      margin-left: 4px;
     }
     .app-header-func-nav{
     }

--- a/frontend/src/style/variables.scss
+++ b/frontend/src/style/variables.scss
@@ -16,12 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-$fake-title-bar-height: 26px;
-$layout-header-height: 60px;
+$fake-title-bar-height: 0px;
+$layout-header-height: 48px;
 $layout-footer-height: 20px;
 $layout-left-sidebar-width: 160px;
 $layout-right-toolbar-width: 60px;
-$layout-sidebar-logo-height: 60px;
+$layout-sidebar-logo-height: 48px;
 
 
 $theme-logo-font-color: #505050;

--- a/frontend/src/view/main/MainFunctions.vue
+++ b/frontend/src/view/main/MainFunctions.vue
@@ -2,69 +2,67 @@
 @import '@/style/variables.scss';
     .header-search-box {
       display: flex;
-      height: 54px;
+      align-items: center;
+      height: 100%;
+      width: 100%;
       padding: 0;
       margin: 0;
 
       .header-navigate-btns {
-        height: 54px;
-        max-width: 120px;
-        padding: 0;
-        margin-left: 16px;
-        margin-right: 14px;
+        height: 100%;
         display: flex;
+        align-items: center;
+        padding: 0;
+        margin: 0 4px 0 0;
+        gap: 2px;
 
         .btn-nav {
-          height: 26px;
-          width: 26px;
-          margin-top: 14px;
+          height: 28px;
+          width: 28px;
           padding: 0;
           text-align: center;
-          font-size: 12px;
-          color: #333;
+          font-size: 13px;
+          color: #555;
           outline: none;
-          border: 1px solid #fefefe;
-          background-color: #fff;
-          box-shadow: none;
+          border: none;
+          background-color: transparent;
+          border-radius: 6px;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
 
-          &:active {
-            box-shadow: none;
-            border: rgba(63, 80, 236, 0.452) 1px solid;
-            // background-color: #d80034;
-            background-color: #fff;
+          &:hover {
+            background-color: rgba(0, 0, 0, 0.06);
           }
-        }
-        .btn-nav-left {
-          border-radius: 10px 0px 0px 10px;
-          margin-left: 9px;
-        }
-        .btn-nav-right {
-          border-radius: 0px 10px 10px 0px;
-          margin-left: 0px;
+          &:active {
+            background-color: rgba(0, 0, 0, 0.1);
+          }
         }
       }
       .header-search-input {
-        height: 54px;
+        flex: 1;
+        height: 32px;
         display: flex;
-        flex-direction: column;
-        justify-content: center;
+        align-items: center;
 
         .n-input {
-          height: 26px;
-          padding: 0 8px;
+          height: 32px;
+          padding: 0 10px;
           margin: 0;
           box-shadow: none;
-          font-size: 15px;
-          // border: 1px solid #f1f1f1;
-          border: none;
-
+          font-size: 14px;
+          border: 1px solid #e0e0e0;
+          border-radius: 8px;
           background-color: #fff;
-          padding-left: 5px;
+
           &:active {
             outline: none;
+            border-color: #bbb;
           }
           &:focus {
             outline: none;
+            border-color: #999;
           }
         }
       }


### PR DESCRIPTION
针对用户反馈的 4 个 UI 问题：

| 问题 | 修复 |
|---|---|
| Logo 太大 | 120px/h1-24px-italic → 72px/h1-16px-semibold |
| 搜索栏太短 | `.header-search-input` 加 `flex:1`，圆角边框，填满可用宽度 |
| 按钮位置不和谐 | 透明背景 + hover + gap 间距 + 垂直居中 |
| macOS 双标题栏 | `$fake-title-bar-height: 0`（Frameless:false 已有原生标题栏） |
| header 过高 | 60px → 48px |

4 文件纯 CSS 改动。视觉效果需 `wails dev` 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)