### PR TITLE
feat(anki): 导出生词本为原生 Anki .apkg

### DIFF
--- a/app.go
+++ b/app.go
@@ -19,14 +19,17 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 
 	"github.com/op/go-logging"
 	"github.com/skratchdot/open-golang/open"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 	"github.com/terasum/medict/internal/entry"
 	"github.com/terasum/medict/internal/utils"
 	"github.com/terasum/medict/pkg/backserver"
 	"github.com/terasum/medict/pkg/model"
 	"github.com/terasum/medict/pkg/service"
+	"github.com/terasum/medict/pkg/service/ankiexport"
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 )
 
@@ -97,6 +100,7 @@ func (b *App) appInit() error {
 
 // startup is called at application startup
 func (b *App) startup(ctx context.Context) {
+	b.ctx = ctx
 	go b.stopChanListen(ctx)
 	go b.errorChanListen(ctx)
 }
@@ -221,6 +225,52 @@ func (b *App) SetDefaultNotebook(id string) *model.Resp {
 		return model.BuildError(err, model.BadParamErrCode)
 	}
 	return model.BuildSuccess(nil)
+}
+
+// ExportAnki exports the given notebook's saved words (all notebooks if id is
+// empty) to a native Anki .apkg. Each word becomes a card carrying its stored
+// HTML snapshot (images extracted as Anki media); each notebook becomes a deck.
+// Prompts the user for a save path via a native dialog.
+func (b *App) ExportAnki(notebookId string) *model.Resp {
+	rows, err := b.bookmarks.ExportRows(notebookId)
+	if err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	if len(rows) == 0 {
+		return model.BuildError(errors.New("没有可导出的生词"), model.BadParamErrCode)
+	}
+
+	path, err := runtime.SaveFileDialog(b.ctx, runtime.SaveDialogOptions{
+		Title:           "导出 Anki 包",
+		DefaultFilename: "medict.apkg",
+		Filters: []runtime.FileFilter{
+			{DisplayName: "Anki Package (*.apkg)", Pattern: "*.apkg"},
+		},
+	})
+	if err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	if path == "" {
+		return model.BuildSuccess(nil) // user cancelled the dialog
+	}
+
+	src := make([]ankiexport.ExportRow, len(rows))
+	for i, r := range rows {
+		src[i] = ankiexport.ExportRow{
+			Word:         r.Word,
+			DictName:     r.DictName,
+			NotebookName: r.NotebookName,
+			HTML:         r.HTML,
+		}
+	}
+	apkg, err := ankiexport.Build(src)
+	if err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	if err := os.WriteFile(path, apkg, 0o644); err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	return model.BuildSuccess(path)
 }
 
 func (b *App) ResourceServerAddr() string {

--- a/frontend/src/apis/bookmark-api.ts
+++ b/frontend/src/apis/bookmark-api.ts
@@ -74,3 +74,15 @@ export const deleteNotebook = async (id: string): Promise<void> => {
 export const setDefaultNotebook = async (id: string): Promise<void> => {
     await unwrap<void>(App.SetDefaultNotebook(id));
 };
+
+// exportAnkiToApkg builds a native Anki .apkg from the given notebook (all
+// notebooks if notebookId is empty) and writes it to a user-chosen path.
+// Returns the saved path, or '' if the user cancelled the save dialog.
+// Throws on backend error (code != 200).
+export const exportAnkiToApkg = async (notebookId: string): Promise<string> => {
+    const resp = await App.ExportAnki(notebookId);
+    if (resp.code !== 200) {
+        throw new Error(resp.err || '导出失败');
+    }
+    return (resp.data as string) || '';
+};

--- a/frontend/src/view/bookmarks/index.vue
+++ b/frontend/src/view/bookmarks/index.vue
@@ -19,6 +19,15 @@
                 <n-icon :component="Search" />
               </template>
             </n-input>
+            <n-button
+              size="small"
+              :loading="exporting"
+              :disabled="store.currentBookmarks.length === 0"
+              @click="onExportAnki"
+            >
+              <template #icon><n-icon><Download /></n-icon></template>
+              导出 Anki
+            </n-button>
           </div>
           <div class="bm-list" v-if="filtered.length > 0">
             <div
@@ -47,14 +56,14 @@
 <script lang="ts" setup>
 import { ref, computed, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
-import { NInput, NButton, NIcon } from 'naive-ui';
-import { Search, Times } from '@vicons/fa';
+import { NInput, NButton, NIcon, useMessage } from 'naive-ui';
+import { Search, Times, Download } from '@vicons/fa';
 import AppHeader from '@/components/layout/AppHeader.vue';
 import NotebookSidebar from '@/components/bookmarks/NotebookSidebar.vue';
 import { useBookmarkStore } from '@/store/bookmark';
 import { useDictQueryStore } from '@/store/dict';
 import { useUIStore } from '@/store/ui';
-import { getBookmarkSnapshot, type Bookmark } from '@/apis/bookmark-api';
+import { getBookmarkSnapshot, exportAnkiToApkg, type Bookmark } from '@/apis/bookmark-api';
 
 const router = useRouter();
 const store = useBookmarkStore();
@@ -63,6 +72,8 @@ const uiStore = useUIStore();
 uiStore.updateCurrentTab('bookmarks');
 
 const filter = ref('');
+const message = useMessage();
+const exporting = ref(false);
 
 const filtered = computed(() => {
   const list = store.currentBookmarks;
@@ -85,6 +96,20 @@ function formatTime(ts: number): string {
 
 async function removeItem(item: Bookmark) {
   await store.removeBookmark(item.word, item.dict_id, item.notebook_id);
+}
+
+async function onExportAnki() {
+  exporting.value = true;
+  try {
+    const path = await exportAnkiToApkg(store.selectedNotebookId);
+    if (path) {
+      message.success(`已导出：${path}`);
+    } // 用户取消保存对话框时不提示
+  } catch (e) {
+    message.error((e as Error)?.message || '导出失败');
+  } finally {
+    exporting.value = false;
+  }
 }
 
 async function lookupWord(item: Bookmark) {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -12,6 +12,8 @@ export function CreateNotebook(arg1:string):Promise<model.Resp>;
 
 export function DeleteNotebook(arg1:string):Promise<model.Resp>;
 
+export function ExportAnki(arg1:string):Promise<model.Resp>;
+
 export function GetAllDicts():Promise<model.Resp>;
 
 export function GetBookmarkSnapshot(arg1:string,arg2:string,arg3:string):Promise<model.Resp>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -22,6 +22,10 @@ export function DeleteNotebook(arg1) {
   return window['go']['main']['App']['DeleteNotebook'](arg1);
 }
 
+export function ExportAnki(arg1) {
+  return window['go']['main']['App']['ExportAnki'](arg1);
+}
+
 export function GetAllDicts() {
   return window['go']['main']['App']['GetAllDicts']();
 }

--- a/pkg/service/ankiexport/apkg.go
+++ b/pkg/service/ankiexport/apkg.go
@@ -1,0 +1,116 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ankiexport
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ExportRow is one card source, produced by BookmarkStore.ExportRows.
+type ExportRow struct {
+	Word         string
+	DictName     string
+	NotebookName string
+	HTML         string
+}
+
+// ErrNoBookmarks is returned by Build when there is nothing to export.
+var ErrNoBookmarks = errors.New("没有可导出的生词")
+
+// Build produces a native Anki .apkg (zip bytes) for the given rows. Each row
+// becomes a card (front = word, back = the snapshot's styled definition with
+// images extracted as Anki media); each notebook becomes a deck.
+func Build(src []ExportRow) ([]byte, error) {
+	if len(src) == 0 {
+		return nil, ErrNoBookmarks
+	}
+
+	media := newMediaCollector()
+	prepared := make([]preparedRow, len(src))
+	for i, r := range src {
+		def := media.rewrite(extractDefinition(r.HTML))
+		nb := r.NotebookName
+		if nb == "" {
+			nb = "Default"
+		}
+		prepared[i] = preparedRow{
+			Word:       r.Word,
+			DictName:   r.DictName,
+			Notebook:   nb,
+			Definition: def,
+		}
+	}
+
+	now := time.Now()
+	colBytes, err := buildCollection(prepared, now.UnixMilli(), now.Unix())
+	if err != nil {
+		return nil, err
+	}
+	return zipApkg(colBytes, media.files)
+}
+
+// zipApkg assembles the final .apkg: collection.anki2, the `media` JSON map, and
+// each media file stored under its numeric key.
+func zipApkg(colBytes []byte, files []mediaFile) ([]byte, error) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	w, err := zw.Create("collection.anki2")
+	if err != nil {
+		return nil, fmt.Errorf("anki: zip collection: %w", err)
+	}
+	if _, err := w.Write(colBytes); err != nil {
+		return nil, fmt.Errorf("anki: write collection: %w", err)
+	}
+
+	mediaMap := make(map[string]string, len(files))
+	for i, f := range files {
+		mediaMap[strconv.Itoa(i)] = f.name
+	}
+	mediaJSON, err := json.Marshal(mediaMap)
+	if err != nil {
+		return nil, fmt.Errorf("anki: marshal media map: %w", err)
+	}
+	w, err = zw.Create("media")
+	if err != nil {
+		return nil, fmt.Errorf("anki: zip media map: %w", err)
+	}
+	if _, err := w.Write(mediaJSON); err != nil {
+		return nil, fmt.Errorf("anki: write media map: %w", err)
+	}
+
+	for i, f := range files {
+		w, err := zw.Create(strconv.Itoa(i))
+		if err != nil {
+			return nil, fmt.Errorf("anki: zip media file %s: %w", f.name, err)
+		}
+		if _, err := w.Write(f.data); err != nil {
+			return nil, fmt.Errorf("anki: write media file %s: %w", f.name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("anki: close zip: %w", err)
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/service/ankiexport/apkg_test.go
+++ b/pkg/service/ankiexport/apkg_test.go
@@ -1,0 +1,274 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ankiexport
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// png1x1B64 is a valid 1x1 transparent PNG.
+const png1x1B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/IvNAAAAAElFTkSuQmCC"
+
+func TestFieldChecksum_MatchesDefinition(t *testing.T) {
+	// Anki's field_checksum = LE uint32 of first 4 bytes of SHA-1 over the
+	// HTML-stripped, whitespace-stripped text.
+	sum := sha1.Sum([]byte("hello"))
+	want := binary.LittleEndian.Uint32(sum[:4])
+	got := fieldChecksum("hello")
+	if got != want {
+		t.Fatalf("fieldChecksum(hello)=%d want %d", got, want)
+	}
+	// HTML + whitespace must be stripped before hashing.
+	if fieldChecksum("<b>hello</b>") != fieldChecksum("hello") {
+		t.Fatalf("fieldChecksum should ignore HTML tags")
+	}
+	if fieldChecksum("h e llo") != fieldChecksum("hello") {
+		t.Fatalf("fieldChecksum should ignore whitespace")
+	}
+}
+
+func TestStripHTMLMedia(t *testing.T) {
+	got := stripHTMLMedia(`<b>hi</b> [sound:a.mp3] <img src="x.png"> [[type:cloze]]`)
+	if got != "hi  " && strings.TrimSpace(got) != "hi" {
+		t.Fatalf("stripHTMLMedia = %q", got)
+	}
+}
+
+func TestParseDataURL(t *testing.T) {
+	raw, err := base64.StdEncoding.DecodeString(png1x1B64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mime, data, ok := parseDataURL("data:image/png;base64," + png1x1B64)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if mime != "image/png" {
+		t.Fatalf("mime=%q want image/png", mime)
+	}
+	if !bytes.Equal(data, raw) {
+		t.Fatalf("decoded bytes mismatch")
+	}
+	if _, _, ok := parseDataURL("https://x/y"); ok {
+		t.Fatal("non-data URL should not parse")
+	}
+}
+
+func TestExtractDefinition_BodyAndStyle(t *testing.T) {
+	doc := `<html><head><style>.x{color:red}</style></head><body><p>hello</p></body></html>`
+	def := extractDefinition(doc)
+	if !strings.Contains(def, ".x{color:red}") {
+		t.Fatalf("style block should be hoisted: %q", def)
+	}
+	if !strings.Contains(def, "<p>hello</p>") {
+		t.Fatalf("body inner should be present: %q", def)
+	}
+	if strings.Contains(def, "<body") {
+		t.Fatalf("body tag should be stripped: %q", def)
+	}
+}
+
+func TestMediaCollector_RewriteAndDedup(t *testing.T) {
+	m := newMediaCollector()
+	img := `<img src="data:image/png;base64,` + png1x1B64 + `">`
+	out := m.rewrite(img + img) // same image twice
+	if len(m.files) != 1 {
+		t.Fatalf("expected 1 deduped media file, got %d", len(m.files))
+	}
+	if !strings.Contains(m.files[0].name, ".png") {
+		t.Fatalf("media filename should end with .png: %q", m.files[0].name)
+	}
+	// Both occurrences rewritten to the same filename.
+	if c := strings.Count(out, m.files[0].name); c != 2 {
+		t.Fatalf("expected 2 refs to media file, got %d in %q", c, out)
+	}
+	if strings.Contains(out, "data:image/png") {
+		t.Fatalf("data: URL should be replaced: %q", out)
+	}
+}
+
+// TestBuild_endToEnd builds a 2-notebook apkg, reopens the zip + the SQLite
+// collection, and asserts the Anki-shaped contents.
+func TestBuild_endToEnd(t *testing.T) {
+	rows := []ExportRow{
+		{
+			Word:         "apple",
+			DictName:     "OALD",
+			NotebookName: "Fruit",
+			HTML:         `<html><head><style>p{color:#000}</style></head><body><p>a fruit</p><img src="data:image/png;base64,` + png1x1B64 + `"></body></html>`,
+		},
+		{
+			Word:         "dog",
+			DictName:     "OALD",
+			NotebookName: "Animals",
+			HTML:         `<html><body><p>a pet</p></body></html>`,
+		},
+	}
+	apkg, err := Build(rows)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(apkg), int64(len(apkg)))
+	if err != nil {
+		t.Fatalf("zip read: %v", err)
+	}
+	files := map[string]*zip.File{}
+	for _, f := range zr.File {
+		files[f.Name] = f
+	}
+	if _, ok := files["collection.anki2"]; !ok {
+		t.Fatal("collection.anki2 missing from apkg")
+	}
+	mediaEntry, ok := files["media"]
+	if !ok {
+		t.Fatal("media map missing from apkg")
+	}
+
+	// The apple card extracted one image → one media file under key "0".
+	mediaMap := readJSONMap(t, mediaEntry)
+	mediaName, hasImg := mediaMap["0"]
+	if !hasImg {
+		t.Fatalf("expected media entry 0, got %v", mediaMap)
+	}
+	if !strings.HasSuffix(mediaName, ".png") {
+		t.Fatalf("media 0 should be png: %q", mediaName)
+	}
+	if _, ok := files["0"]; !ok {
+		t.Fatal("media file bytes missing under key 0")
+	}
+
+	// Reopen collection.anki2 and assert Anki shape.
+	col := openCol(t, files["collection.anki2"])
+	defer col.Close()
+
+	var noteCnt, cardCnt int
+	if err := col.QueryRow(`SELECT COUNT(*) FROM notes`).Scan(&noteCnt); err != nil {
+		t.Fatal(err)
+	}
+	if err := col.QueryRow(`SELECT COUNT(*) FROM cards`).Scan(&cardCnt); err != nil {
+		t.Fatal(err)
+	}
+	if noteCnt != 2 || cardCnt != 2 {
+		t.Fatalf("notes=%d cards=%d, want 2/2", noteCnt, cardCnt)
+	}
+
+	// The apple note's flds must reference the extracted image filename and carry
+	// the word in field 0 (flds joined by 0x1f).
+	var appleFlds string
+	if err := col.QueryRow(`SELECT flds FROM notes WHERE tags LIKE ?`, "%fruit%").Scan(&appleFlds); err != nil {
+		// tag is lowercased notebook name; fall back to scanning all if tag guess misses
+		if err := col.QueryRow(`SELECT flds FROM notes ORDER BY id LIMIT 1 OFFSET 0`).Scan(&appleFlds); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !strings.Contains(appleFlds, mediaName) {
+		t.Fatalf("apple flds should reference media %q: %q", mediaName, appleFlds)
+	}
+	parts := strings.Split(appleFlds, "\x1f")
+	if len(parts) < 2 || parts[0] != "apple" {
+		t.Fatalf("field0 should be the word 'apple': %q", appleFlds)
+	}
+
+	// col row present with models/decks JSON.
+	var modelsJSON, decksJSON string
+	if err := col.QueryRow(`SELECT models, decks FROM col`).Scan(&modelsJSON, &decksJSON); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(modelsJSON, "Medict Word") {
+		t.Fatalf("models JSON missing Medict Word: %s", modelsJSON)
+	}
+	if !strings.Contains(decksJSON, "Medict::Fruit") || !strings.Contains(decksJSON, "Medict::Animals") {
+		t.Fatalf("decks JSON missing notebook decks: %s", decksJSON)
+	}
+	// Each note's card lives in its notebook's deck.
+	var dids []int64
+	rowsQ, err := col.Query(`SELECT DISTINCT did FROM cards`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rowsQ.Next() {
+		var d int64
+		rowsQ.Scan(&d)
+		dids = append(dids, d)
+	}
+	rowsQ.Close()
+	if len(dids) != 2 {
+		t.Fatalf("expected 2 distinct deck ids, got %d (%v)", len(dids), dids)
+	}
+}
+
+func TestBuild_Empty(t *testing.T) {
+	if _, err := Build(nil); err != ErrNoBookmarks {
+		t.Fatalf("Build(nil) err=%v want ErrNoBookmarks", err)
+	}
+}
+
+// --- helpers ---
+
+func readJSONMap(t *testing.T, f *zip.File) map[string]string {
+	t.Helper()
+	rc, err := f.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(rc); err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// openCol writes the zipped collection bytes to a temp file and opens it.
+func openCol(t *testing.T, f *zip.File) *sql.DB {
+	t.Helper()
+	rc, err := f.Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(rc); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "collection.anki2")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}

--- a/pkg/service/ankiexport/collection.go
+++ b/pkg/service/ankiexport/collection.go
@@ -1,0 +1,459 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package ankiexport turns bookmark snapshots into a native Anki .apkg.
+//
+// An .apkg is a zip containing:
+//   - collection.anki2  — a SQLite DB with Anki's schema (col/notes/cards/...)
+//   - media             — JSON mapping numeric keys ("0","1",...) → media filenames
+//   - the media bytes    — stored in the zip under the numeric keys
+//
+// This file builds collection.anki2. The SQLite schema, the col-row JSON
+// (models/decks/dconf/conf), the new-card scheduling fields and the field
+// checksum mirror Anki's own format (see Anki's db.py / utils.field_checksum,
+// and genanki's defaults).
+package ankiexport
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	// CGO-free pure-Go SQLite driver (database/sql). Same driver the bookmark
+	// store uses; we write a stand-alone .anki2 (journal OFF, clean close).
+	_ "modernc.org/sqlite"
+)
+
+// ankiSchemaVer is the collection schema version Anki 2.1 expects.
+const ankiSchemaVer = 18
+
+// modelID is the stable note-type id for the "Medict Word" model.
+const modelID int64 = 1700000000119
+
+// preparedRow is an ExportRow after media extraction: its Definition HTML has
+// every <img>/audio data: URL rewritten to a media filename, and the bytes are
+// collected by the media builder for the zip.
+type preparedRow struct {
+	Word       string
+	DictName   string
+	Notebook   string
+	Definition string
+}
+
+// fieldChecksum mirrors Anki's utils.field_checksum: strip HTML/media, drop all
+// whitespace, lowercase-not-applied (Anki lowercases only for display), take the
+// first 4 bytes of SHA-1 as a little-endian uint32. Used for duplicate detection.
+func fieldChecksum(field string) uint32 {
+	s := stripHTMLMedia(field)
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, " ", "")
+	s = anyWhitespace.ReplaceAllString(s, "")
+	sum := sha1.Sum([]byte(s))
+	return binary.LittleEndian.Uint32(sum[:4])
+}
+
+var (
+	anyWhitespace  = regexp.MustCompile(`\s`)
+	htmlTagOrMedia = regexp.MustCompile(`(?s)\[\[type:[^]]+\]\]|<[^>]+>|\[sound:[^]]*\]`)
+)
+
+// stripHTMLMedia removes HTML tags, [sound:..] refs and [[type:..]] cloze markers
+// so the checksum is computed on visible text only (matches Anki.stripHTMLMedia).
+func stripHTMLMedia(s string) string {
+	return htmlTagOrMedia.ReplaceAllString(s, "")
+}
+
+// guidFor returns a stable, unique-enough note guid (Anki stores guids as TEXT;
+// 10 hex chars from a content hash is plenty and keeps re-exports deterministic).
+func guidFor(word, notebook, dict string) string {
+	h := sha1.Sum([]byte(word + "\x1f" + notebook + "\x1f" + dict))
+	return fmt.Sprintf("%x", h[:5]) // 10 hex chars
+}
+
+// deckID derives a stable, positive deck id from a notebook name.
+func deckID(name string) int64 {
+	h := sha1.Sum([]byte("deck:" + name))
+	id := int64(binary.BigEndian.Uint64(h[:8]) % 1_000_000_000_000)
+	if id < 0 {
+		id = -id
+	}
+	if id == 0 {
+		id = 1
+	}
+	return id
+}
+
+// buildCollection writes a valid collection.anki2 for the prepared rows into a
+// temp file and returns its bytes. prepared must be non-empty.
+func buildCollection(prepared []preparedRow, modMs, crtSec int64) ([]byte, error) {
+	tmp, err := os.CreateTemp("", "medict-anki-*.anki2")
+	if err != nil {
+		return nil, fmt.Errorf("anki: temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	db, err := sql.Open("sqlite", tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("anki: open db: %w", err)
+	}
+	// Keep the file a single self-contained .anki2 (no -wal/-shm sidecars).
+	if _, err := db.Exec(`PRAGMA journal_mode = OFF;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("anki: pragma journal: %w", err)
+	}
+
+	if err := createAnkiSchema(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	// One deck per notebook (name "Medict::<notebook>"), plus the Default deck 1.
+	decks := map[string]any{
+		"1": deckDict(1, "Default", modMs),
+	}
+	for _, name := range uniqueNotebooks(prepared) {
+		did := deckID(name)
+		decks[strconv.FormatInt(did, 10)] = deckDict(did, "Medict::"+name, modMs)
+	}
+
+	models := map[string]any{strconv.FormatInt(modelID, 10): medictModel(modMs)}
+	colRow, err := buildColRow(models, decks, defaultDconf(modMs), defaultConf(int64(len(prepared))), modMs, crtSec)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.Exec(colInsertSQL, colRow...); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("anki: insert col: %w", err)
+	}
+
+	noteStmt, err := db.Prepare(noteInsertSQL)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("anki: prepare note: %w", err)
+	}
+	defer noteStmt.Close()
+	cardStmt, err := db.Prepare(cardInsertSQL)
+	if err != nil {
+		db.Close()
+		return nil, fmt.Errorf("anki: prepare card: %w", err)
+	}
+	defer cardStmt.Close()
+
+	baseID := modMs
+	var idCounter int64
+	for _, r := range prepared {
+		noteID := baseID + idCounter
+		idCounter++
+		cardID := baseID + idCounter
+		idCounter++
+
+		tags := cleanTag(r.Notebook)
+		if d := cleanTag(r.DictName); d != "" {
+			tags = strings.TrimSpace(tags + " " + d)
+		}
+		flds := r.Word + "\x1f" + r.Definition + "\x1f" + r.DictName
+		if _, err := noteStmt.Exec(noteID, guidFor(r.Word, r.Notebook, r.DictName), modelID, modMs, -1,
+			tags, flds, r.Word, int64(fieldChecksum(r.Word)), 0, ""); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("anki: insert note %q: %w", r.Word, err)
+		}
+		// New card: type=0(new), queue=0(new), due=position, rest zeroed.
+		duePos := idCounter / 2 // monotonic new-card position
+		if _, err := cardStmt.Exec(cardID, noteID, deckID(r.Notebook), 0, modMs, -1,
+			0, 0, duePos, 0, 0, 0, 0, 0, 0, 0, 0, ""); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("anki: insert card %q: %w", r.Word, err)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		return nil, fmt.Errorf("anki: close db: %w", err)
+	}
+	return os.ReadFile(tmpPath)
+}
+
+// createAnkiSchema creates Anki's tables + indexes (DDL mirrors Anki db.py).
+func createAnkiSchema(db *sql.DB) error {
+	const ddl = `
+CREATE TABLE col (
+    crt     INTEGER NOT NULL,
+    mod     INTEGER NOT NULL,
+    scm     INTEGER NOT NULL,
+    ver     INTEGER NOT NULL,
+    dty     INTEGER NOT NULL,
+    usn     INTEGER NOT NULL,
+    ls      INTEGER NOT NULL,
+    conf    TEXT NOT NULL,
+    models  TEXT NOT NULL,
+    decks   TEXT NOT NULL,
+    dconf   TEXT NOT NULL,
+    tags    TEXT NOT NULL
+);
+CREATE TABLE notes (
+    id    INTEGER PRIMARY KEY,
+    guid  TEXT NOT NULL,
+    mid   INTEGER NOT NULL,
+    mod   INTEGER NOT NULL,
+    usn   INTEGER NOT NULL,
+    tags  TEXT NOT NULL,
+    flds  TEXT NOT NULL,
+    sfld  INTEGER NOT NULL,
+    csum  INTEGER NOT NULL,
+    flags INTEGER NOT NULL,
+    data  TEXT NOT NULL
+);
+CREATE TABLE cards (
+    id      INTEGER PRIMARY KEY,
+    nid     INTEGER NOT NULL,
+    did     INTEGER NOT NULL,
+    ord     INTEGER NOT NULL,
+    mod     INTEGER NOT NULL,
+    usn     INTEGER NOT NULL,
+    type    INTEGER NOT NULL,
+    queue   INTEGER NOT NULL,
+    due     INTEGER NOT NULL,
+    ivl     INTEGER NOT NULL,
+    factor  INTEGER NOT NULL,
+    reps    INTEGER NOT NULL,
+    lapses  INTEGER NOT NULL,
+    left    INTEGER NOT NULL,
+    odue    INTEGER NOT NULL,
+    odid    INTEGER NOT NULL,
+    flags   INTEGER NOT NULL,
+    data    TEXT NOT NULL
+);
+CREATE TABLE revlog (
+    id      INTEGER PRIMARY KEY,
+    cid     INTEGER NOT NULL,
+    usn     INTEGER NOT NULL,
+    ease    INTEGER NOT NULL,
+    ivl     INTEGER NOT NULL,
+    lastIvl INTEGER NOT NULL,
+    factor  INTEGER NOT NULL,
+    time    INTEGER NOT NULL,
+    type    INTEGER NOT NULL
+);
+CREATE TABLE graves (
+    usn  INTEGER NOT NULL,
+    oid  INTEGER NOT NULL,
+    type INTEGER NOT NULL
+);
+CREATE INDEX ix_notes_usn ON notes (usn);
+CREATE INDEX ix_notes_csum ON notes (csum);
+CREATE INDEX ix_notes_dup ON notes (mid, csum);
+CREATE INDEX ix_cards_usn ON cards (usn);
+CREATE INDEX ix_cards_nid ON cards (nid);
+CREATE INDEX ix_cards_sched ON cards (did, queue, due);
+CREATE INDEX ix_revlog_usn ON revlog (usn);
+CREATE INDEX ix_revlog_cid ON revlog (cid);
+`
+	_, err := db.Exec(ddl)
+	return err
+}
+
+const (
+	colInsertSQL = `INSERT INTO col(crt,mod,scm,ver,dty,usn,ls,conf,models,decks,dconf,tags) VALUES(?,?,?,?,?,?,?,?,?,?,?,?);`
+	noteInsertSQL = `INSERT INTO notes(id,guid,mid,mod,usn,tags,flds,sfld,csum,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?);`
+	cardInsertSQL = `INSERT INTO cards(id,nid,did,ord,mod,usn,type,queue,due,ivl,factor,reps,lapses,left,odue,odid,flags,data) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);`
+)
+
+// buildColRow returns the 12 col-column values, marshalling the four JSON blobs.
+func buildColRow(models, decks, dconf, conf map[string]any, modMs, crtSec int64) ([]any, error) {
+	mkJSON := func(v any) (any, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return string(b), nil
+	}
+	confJ, err := mkJSON(conf)
+	if err != nil {
+		return nil, fmt.Errorf("anki: marshal conf: %w", err)
+	}
+	modelsJ, err := mkJSON(models)
+	if err != nil {
+		return nil, fmt.Errorf("anki: marshal models: %w", err)
+	}
+	decksJ, err := mkJSON(decks)
+	if err != nil {
+		return nil, fmt.Errorf("anki: marshal decks: %w", err)
+	}
+	dconfJ, err := mkJSON(dconf)
+	if err != nil {
+		return nil, fmt.Errorf("anki: marshal dconf: %w", err)
+	}
+	return []any{crtSec, modMs, crtSec * 1000, ankiSchemaVer, 0, -1, 0, confJ, modelsJ, decksJ, dconfJ, ""}, nil
+}
+
+// medictModel returns the "Medict Word" note type: fields Word/Definition/Dict,
+// one forward template (front = Word, back = Definition).
+func medictModel(modMs int64) map[string]any {
+	return map[string]any{
+		"id":      modelID,
+		"name":    "Medict Word",
+		"type":    0,
+		"mod":     modMs,
+		"usn":     -1,
+		"sortf":   0,
+		"did":     nil,
+		"tmpls": []map[string]any{{
+			"name":  "Word-Definition",
+			"ord":   0,
+			"qfmt":  "{{Word}}",
+			"afmt":  `{{FrontSide}}<hr id="answer">{{Definition}}<br><div style="color:#999;font-size:14px">{{Dict}}</div>`,
+			"bqfmt": "",
+			"bafmt": "",
+			"did":   nil,
+			"mode":  0,
+		}},
+		"flds": []map[string]any{
+			{"name": "Word", "ord": 0, "sticky": false, "rtl": false, "font": "Arial", "size": 28},
+			{"name": "Definition", "ord": 1, "sticky": false, "rtl": false, "font": "Arial", "size": 20},
+			{"name": "Dict", "ord": 2, "sticky": false, "rtl": false, "font": "Arial", "size": 14},
+		},
+		"css":           `.card{font-family:Arial;font-size:20px;text-align:left;color:#222;background:#fff;line-height:1.5;}`,
+		"req":           [][]any{{"Word-Definition", "any", []any{0}}},
+		"latexPostamble": "",
+		"latexPreamble":  "",
+		"latexsvg":       false,
+		"vers":           []any{},
+		"tags":           []any{},
+		"version":        0,
+	}
+}
+
+// deckDict returns one entry of the decks JSON.
+func deckDict(id int64, name string, modMs int64) map[string]any {
+	return map[string]any{
+		"id":                id,
+		"name":              name,
+		"mod":               modMs,
+		"usn":               -1,
+		"desc":              "",
+		"dyn":               0,
+		"collapsed":         false,
+		"browserCollapsed":  false,
+		"extendNew":         10,
+		"extendRev":         50,
+		"conf":              1,
+		"newToday":          []any{0, 0},
+		"revToday":          []any{0, 0},
+		"lrnToday":          []any{0, 0},
+		"timeToday":         []any{0, 0},
+	}
+}
+
+// defaultDconf returns the default deck config (id 1) Anki ships with.
+func defaultDconf(modMs int64) map[string]any {
+	return map[string]any{
+		"1": map[string]any{
+			"id":        1,
+			"mod":       modMs,
+			"usn":       -1,
+			"name":      "Default",
+			"autoplay":  true,
+			"dyn":       0,
+			"maxTaken":  60,
+			"timer":     0,
+			"replayq":   true,
+			"hash":      "37c3a0581407a8d3",
+			"new": map[string]any{
+				"bury":         false,
+				"delays":       []any{1, 10},
+				"initialFactor": 2500,
+				"ints":          []any{1, 4, 7},
+				"order":         1,
+				"perDay":        20,
+				"separate":      false,
+			},
+			"rev": map[string]any{
+				"bury":       false,
+				"ease4":      1.3,
+				"fuzz":       0.05,
+				"ivlFct":     1.0,
+				"maxIvl":     36500,
+				"minSpace":   1,
+				"perDay":     200,
+				"hardFactor": 1.2,
+			},
+			"lapse": map[string]any{
+				"delays":      []any{10},
+				"leechAction": 1,
+				"leechFails":  8,
+				"minInt":      1,
+				"mult":        0.5,
+			},
+		},
+	}
+}
+
+// defaultConf returns the col.conf scheduler blob. nextPos is the next new-card
+// position after this import.
+func defaultConf(nextPos int64) map[string]any {
+	return map[string]any{
+		"activeDecks":    []any{int64(1)},
+		"curDeck":        int64(1),
+		"curModel":       nil,
+		"dueCounts":      true,
+		"estTimes":       true,
+		"newBury":        true,
+		"newSpread":      int64(0),
+		"nextPos":        nextPos,
+		"sortBackwards":  false,
+		"schedVer":       int64(1),
+	}
+}
+
+// uniqueNotebooks returns the sorted unique notebook names among the rows.
+func uniqueNotebooks(rows []preparedRow) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0)
+	for _, r := range rows {
+		if r.Notebook == "" {
+			r.Notebook = "Default"
+		}
+		if _, ok := seen[r.Notebook]; ok {
+			continue
+		}
+		seen[r.Notebook] = struct{}{}
+		out = append(out, r.Notebook)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cleanTag turns an arbitrary label into an Anki-safe tag (lowercased, no
+// spaces/special chars; spaces → underscores).
+func cleanTag(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "/", "_")
+	return s
+}

--- a/pkg/service/ankiexport/media.go
+++ b/pkg/service/ankiexport/media.go
@@ -1,0 +1,180 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ankiexport
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// mediaFile is one extracted resource (image/audio) written into the .apkg.
+type mediaFile struct {
+	name string
+	data []byte
+}
+
+// mediaCollector dedups extracted resources by SHA-1 (so the same image reused
+// across many cards is stored once) and assigns each a stable filename.
+type mediaCollector struct {
+	byHash map[string]string // sha1(hex) → filename
+	files  []mediaFile
+}
+
+func newMediaCollector() *mediaCollector {
+	return &mediaCollector{byHash: map[string]string{}}
+}
+
+func (m *mediaCollector) add(mime string, data []byte) string {
+	sum := sha1.Sum(data)
+	h := hex.EncodeToString(sum[:])
+	if name, ok := m.byHash[h]; ok {
+		return name
+	}
+	name := "medict-" + h + extForMime(mime)
+	m.byHash[h] = name
+	m.files = append(m.files, mediaFile{name: name, data: data})
+	return name
+}
+
+// srcDataReg matches element resource attributes pointing at a data: URL, e.g.
+// <img src="data:image/png;base64,...">. It deliberately matches only src= (not
+// href=), so inlined CSS on <link href="data:..."> stays put (the Anki reviewer
+// renders it via its webview). Group 1 = `src="` prefix (with its spacing),
+// group 2 = the data: URL body, group 3 = the closing quote.
+var srcDataReg = regexp.MustCompile(`(src\s*=\s*")(data:[^"]*)(")`)
+
+// rewrite replaces every src="data:..." in html with src="<filename>", recording
+// the extracted bytes on the collector. Unparseable data: URLs are left as-is.
+func (m *mediaCollector) rewrite(html string) string {
+	return srcDataReg.ReplaceAllStringFunc(html, func(match string) string {
+		sub := srcDataReg.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		mime, data, ok := parseDataURL(sub[2])
+		if !ok {
+			return match
+		}
+		return sub[1] + m.add(mime, data) + sub[3]
+	})
+}
+
+// parseDataURL decodes a `data:[<mime>][;base64],<payload>` URL. Returns ok=false
+// for anything that isn't a decodable data: URL.
+func parseDataURL(url string) (mime string, data []byte, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(url, prefix) {
+		return "", nil, false
+	}
+	rest := url[len(prefix):]
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", nil, false
+	}
+	header, payload := rest[:comma], rest[comma+1:]
+	mime = header
+	if i := strings.IndexByte(header, ';'); i >= 0 {
+		mime = header[:i]
+	}
+	if mime == "" || mime == "data" {
+		mime = "application/octet-stream"
+	}
+	if strings.Contains(header, ";base64") {
+		dec, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			return "", nil, false
+		}
+		return mime, dec, true
+	}
+	// Rare: URL-encoded payload (no ;base64).
+	return mime, []byte(payload), true
+}
+
+// extForMime maps a MIME type to a file extension (mirror of handler.mimeByExt).
+func extForMime(mime string) string {
+	switch strings.ToLower(mime) {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/svg+xml":
+		return ".svg"
+	case "image/webp":
+		return ".webp"
+	case "image/bmp":
+		return ".bmp"
+	case "image/x-icon":
+		return ".ico"
+	case "audio/mpeg", "audio/mp3":
+		return ".mp3"
+	case "audio/wav":
+		return ".wav"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/mp4", "audio/m4a":
+		return ".m4a"
+	case "text/css":
+		return ".css"
+	case "text/javascript", "application/javascript":
+		return ".js"
+	case "font/woff":
+		return ".woff"
+	case "font/woff2":
+		return ".woff2"
+	case "font/ttf":
+		return ".ttf"
+	case "font/otf":
+		return ".otf"
+	case "application/vnd.ms-fontobject":
+		return ".eot"
+	default:
+		return ".bin"
+	}
+}
+
+// styleBlockReg matches a full <style>...</style> block (dotall).
+var styleBlockReg = regexp.MustCompile(`(?si)<style[^>]*>.*?</style>`)
+
+// bodyReg captures the inner HTML of <body> (dotall, non-greedy).
+var bodyReg = regexp.MustCompile(`(?si)<body[^>]*>(.*?)</body>`)
+
+// extractDefinition turns a full snapshot HTML document into a card field value:
+// the <body> inner HTML prefixed with any <style> blocks (so dictionary styling
+// survives). If there's no <body>, the whole input is used. The caller rewrites
+// src="data:..." images to media filenames afterwards.
+func extractDefinition(htmlStr string) string {
+	styles := styleBlockReg.FindAllString(htmlStr, -1)
+	inner := ""
+	if m := bodyReg.FindStringSubmatch(htmlStr); len(m) >= 2 {
+		inner = m[1]
+	} else {
+		inner = htmlStr
+	}
+	// Drop <style> from the body inner (already hoisted) to avoid duplication.
+	inner = styleBlockReg.ReplaceAllString(inner, "")
+	var b strings.Builder
+	for _, s := range styles {
+		b.WriteString(s)
+	}
+	b.WriteString(inner)
+	return b.String()
+}

--- a/pkg/service/bookmark_store.go
+++ b/pkg/service/bookmark_store.go
@@ -54,6 +54,17 @@ type Bookmark struct {
 	SavedAt    int64  `json:"saved_at"`
 }
 
+// ExportRow is one saved word bundled with its notebook name and stored HTML
+// snapshot — everything the Anki exporter needs to build a card. Returned by
+// ExportRows; unlike Bookmark it carries the (potentially large) snapshot HTML.
+type ExportRow struct {
+	Word         string `json:"word"`
+	DictName     string `json:"dict_name"`
+	NotebookName string `json:"notebook_name"`
+	HTML         string `json:"html"`
+	SavedAt      int64  `json:"saved_at"`
+}
+
 // BookmarkStore persists notebooks + saved words (with self-contained HTML
 // snapshots) to a SQLite file (bookmarks.db) in the app config dir. Uses the
 // pure-Go modernc.org/sqlite driver — no CGO. Single serialized connection
@@ -209,6 +220,34 @@ func (s *BookmarkStore) All() ([]Bookmark, error) {
 			return nil, err
 		}
 		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// ExportRows returns saved words with their notebook name + stored HTML snapshot,
+// newest first. notebookId == "" returns words from every notebook. Used by the
+// Anki exporter; each row is one card, each notebook is one deck.
+func (s *BookmarkStore) ExportRows(notebookId string) ([]ExportRow, error) {
+	q := `SELECT b.word, b.dict_name, n.name, b.content_html, b.saved_at
+	      FROM bookmarks b JOIN notebooks n ON n.id = b.notebook_id`
+	var args []any
+	if notebookId != "" {
+		q += ` WHERE b.notebook_id = ?`
+		args = append(args, notebookId)
+	}
+	q += ` ORDER BY b.saved_at DESC, b.id DESC`
+	rows, err := s.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]ExportRow, 0)
+	for rows.Next() {
+		var r ExportRow
+		if err := rows.Scan(&r.Word, &r.DictName, &r.NotebookName, &r.HTML, &r.SavedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
 	}
 	return out, rows.Err()
 }


### PR DESCRIPTION
> 替代被自动关闭的 #773(其 base 分支在 #772 合并时删除导致关闭)。本 PR 即原 anki-export 工作,现直接对 develop。基于已合并的 #772(生词本 v2)。

## 概述
实现 README roadmap 的「导出 anki 卡片」:把生词本里的词(+ 离线 HTML 快照)导出为**原生 Anki `.apkg`**,用户可直接导入 Anki 桌面端用 SRS 复习。每条生词一张卡(正面=词,背面=释义),每个笔记本一个 deck(`Medict::<笔记本名>`)。

## 改动
- **新包 `pkg/service/ankiexport`** — 产出符合 Anki 规范的 `.apkg`:
  - `collection.go`:modernc.org/sqlite 建 Anki schema(col/notes/cards/revlog/graves + 索引),写 col 行的 models/decks/dconf/conf JSON;guid/字段校验和(csum)/新卡调度字段对照 Anki 与 genanki 实现。`PRAGMA journal_mode=OFF` + 干净关闭 → 单文件 `.anki2` 无 WAL 旁车。
  - `media.go`:从快照 HTML 抽 `<img>` 的 `data:` URL → Anki 媒体文件(`medict-<sha1>.<ext>`,按 hash 去重),引用改写为文件名;CSS `url(data:)` 与 `<link>` CSS 留内联由 webview 渲染。抽 `<body>` 内部 + `<style>` 作卡片字段。
  - `apkg.go`:编排 + zip 打包(`collection.anki2` + `media` JSON map + 媒体文件)。
- **`BookmarkStore.ExportRows(notebookId)`** — JOIN notebooks 一次取出 词+笔记本名+快照 HTML。
- **`app.go`** — `startup` 设 `b.ctx`;新增 `ExportAnki(notebookId)` IPC:`SaveFileDialog` → 构建 → `os.WriteFile`(取消/无数据安全处理)。
- **前端** — 生词本页加「导出 Anki」按钮(导出当前笔记本,空本禁用);`bookmark-api` 增 `exportAnkiToApkg`;wailsjs 绑定 `ExportAnki` 已重生成。

## 验证
- `go build ./...` ✅　`go test ./...` ✅(ankiexport:csum/解析/抽取/去重改写/端到端重开 SQLite 校验)　前端 `bun run build` ✅
- ⚠️ 仍需:用 Anki 桌面端真实导入生成的 `.apkg` 做回归(本方案最大不确定性)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)