### PR TITLE
fix(anki): 修正 .apkg schema 使 Anki 能导入 (ver=11, tags={})

### DIFF
--- a/pkg/service/ankiexport/apkg_anki_compat_test.go
+++ b/pkg/service/ankiexport/apkg_anki_compat_test.go
@@ -1,0 +1,130 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package ankiexport
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validatorScript imports Anki's own AnkiPackageImporter (the exact code path
+// Anki uses when a user imports an .apkg), imports the package into a fresh
+// collection, and prints a JSON summary on stdout. It mirrors /tmp/validate_apkg.py.
+const validatorScript = `import json, os, sys, tempfile, warnings
+import anki.lang
+from anki.collection import Collection
+from anki.importing.apkg import AnkiPackageImporter
+warnings.filterwarnings("ignore")  # silence Anki's deprecation notice
+anki.lang.set_lang("en")
+apkg_path, out_path = sys.argv[1], sys.argv[2]
+work = tempfile.mkdtemp(prefix="anki-compat-")
+dst = Collection(os.path.join(work, "v.anki2"))
+imp = AnkiPackageImporter(dst, apkg_path)
+imp.run()
+notes = dst.find_notes("")
+sample = None
+if notes:
+    n = dst.get_note(notes[0])
+    sample = {fname: n[fname] for fname in n.keys()}
+res = {
+    "notes": len(notes),
+    "cards": len(dst.find_cards("")),
+    "decks": [d.name for d in dst.decks.all_names_and_ids()],
+    "definition": (sample or {}).get("Definition", ""),
+}
+dst.close()
+with open(out_path, "w") as f:
+    json.dump(res, f)
+`
+
+// sampleExportRows builds two cards across two notebooks, one carrying an
+// inlined image, exercising the full builder.
+func sampleExportRows() []ExportRow {
+	return []ExportRow{
+		{
+			Word: "apple", DictName: "OALD", NotebookName: "Fruit",
+			HTML: `<html><head><style>p{color:#000}</style></head><body><p>a round fruit</p><img src="data:image/png;base64,` + png1x1B64 + `"></body></html>`,
+		},
+		{Word: "dog", DictName: "OALD", NotebookName: "Animals",
+			HTML: `<html><body><p>a common pet</p></body></html>`},
+	}
+}
+
+// TestAnkiPackageCompat is the gold-standard compatibility check: it feeds a
+// generated .apkg to Anki's own importer (AnkiPackageImporter) and asserts the
+// notes/cards/decks/media land. It is gated behind the ANKI_VALIDATE_PYTHON env
+// var (a path to a Python interpreter with the `anki` package installed) so the
+// default test run needs no Python; set the env var to opt in.
+//
+//	pip install anki genanki
+//	ANKI_VALIDATE_PYTHON=/path/to/venv/bin/python go test ./pkg/service/ankiexport/ -run TestAnkiPackageCompat -count=1
+func TestAnkiPackageCompat(t *testing.T) {
+	py := os.Getenv("ANKI_VALIDATE_PYTHON")
+	if py == "" {
+		t.Skip("set ANKI_VALIDATE_PYTHON=<path to python with anki installed> to validate against Anki's importer")
+	}
+
+	apkg, err := Build(sampleExportRows())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	dir := t.TempDir()
+	apkgPath := filepath.Join(dir, "sample.apkg")
+	if err := os.WriteFile(apkgPath, apkg, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(dir, "validate_apkg.py")
+	if err := os.WriteFile(scriptPath, []byte(validatorScript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	resultPath := filepath.Join(dir, "result.json")
+
+	cmd := exec.Command(py, scriptPath, apkgPath, resultPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Anki importer rejected the .apkg: %v\n%s", err, out)
+	}
+
+	resBytes, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("read importer result (%s): %v", resultPath, err)
+	}
+	var res struct {
+		Notes      int      `json:"notes"`
+		Cards      int      `json:"cards"`
+		Decks      []string `json:"decks"`
+		Definition string   `json:"definition"`
+	}
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		t.Fatalf("parse importer result: %v\nraw: %s", err, resBytes)
+	}
+	if res.Notes != 2 || res.Cards != 2 {
+		t.Fatalf("imported notes=%d cards=%d, want 2/2", res.Notes, res.Cards)
+	}
+	decks := strings.Join(res.Decks, ",")
+	if !strings.Contains(decks, "Medict::Fruit") || !strings.Contains(decks, "Medict::Animals") {
+		t.Fatalf("notebook decks not created: %v", res.Decks)
+	}
+	// Image must have been extracted to an Anki media file and referenced by name.
+	if !strings.Contains(res.Definition, "medict-") || !strings.Contains(res.Definition, ".png") {
+		t.Fatalf("definition should reference an extracted media file: %q", res.Definition)
+	}
+	t.Logf("Anki importer OK: %d notes, %d cards, decks=%v", res.Notes, res.Cards, res.Decks)
+}

--- a/pkg/service/ankiexport/apkg_test.go
+++ b/pkg/service/ankiexport/apkg_test.go
@@ -201,6 +201,21 @@ func TestBuild_endToEnd(t *testing.T) {
 	if err := col.QueryRow(`SELECT models, decks FROM col`).Scan(&modelsJSON, &decksJSON); err != nil {
 		t.Fatal(err)
 	}
+	// Anki-compat guards: ver must be 11 (older schema so Anki upgrades
+	// col.models JSON → notetypes table on open) and tags must be "{}" (the
+	// backend parses col.tags as JSON; an empty string throws EOF). These two
+	// are the exact bugs found by the AnkiPackageImporter validation.
+	var colVer int
+	var colTags string
+	if err := col.QueryRow(`SELECT ver, tags FROM col`).Scan(&colVer, &colTags); err != nil {
+		t.Fatal(err)
+	}
+	if colVer != 11 {
+		t.Fatalf("col.ver=%d want 11", colVer)
+	}
+	if colTags != "{}" {
+		t.Fatalf("col.tags=%q want {}", colTags)
+	}
 	if !strings.Contains(modelsJSON, "Medict Word") {
 		t.Fatalf("models JSON missing Medict Word: %s", modelsJSON)
 	}

--- a/pkg/service/ankiexport/collection.go
+++ b/pkg/service/ankiexport/collection.go
@@ -44,8 +44,12 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-// ankiSchemaVer is the collection schema version Anki 2.1 expects.
-const ankiSchemaVer = 18
+// ankiSchemaVer is the collection schema version we write. We deliberately use
+// the legacy value 11 (matching genanki): on open, Anki upgrades a v11
+// collection, migrating col.models JSON into the modern `notetypes` table.
+// Writing a newer ver without the `notetypes` table makes Anki fail with
+// "no such table: notetypes".
+const ankiSchemaVer = 11
 
 // modelID is the stable note-type id for the "Medict Word" model.
 const modelID int64 = 1700000000119
@@ -305,7 +309,10 @@ func buildColRow(models, decks, dconf, conf map[string]any, modMs, crtSec int64)
 	if err != nil {
 		return nil, fmt.Errorf("anki: marshal dconf: %w", err)
 	}
-	return []any{crtSec, modMs, crtSec * 1000, ankiSchemaVer, 0, -1, 0, confJ, modelsJ, decksJ, dconfJ, ""}, nil
+	// tags column is parsed as JSON by Anki's backend on open (ver=11 upgrade),
+	// so it must be a valid JSON object ("{}"), not an empty string (which throws
+	// "EOF while parsing a value").
+	return []any{crtSec, modMs, crtSec * 1000, ankiSchemaVer, 0, -1, 0, confJ, modelsJ, decksJ, dconfJ, "{}"}, nil
 }
 
 // medictModel returns the "Medict Word" note type: fields Word/Definition/Dict,
@@ -330,9 +337,9 @@ func medictModel(modMs int64) map[string]any {
 			"mode":  0,
 		}},
 		"flds": []map[string]any{
-			{"name": "Word", "ord": 0, "sticky": false, "rtl": false, "font": "Arial", "size": 28},
-			{"name": "Definition", "ord": 1, "sticky": false, "rtl": false, "font": "Arial", "size": 20},
-			{"name": "Dict", "ord": 2, "sticky": false, "rtl": false, "font": "Arial", "size": 14},
+			{"name": "Word", "ord": 0, "sticky": false, "rtl": false, "font": "Arial", "size": 28, "media": []any{}},
+			{"name": "Definition", "ord": 1, "sticky": false, "rtl": false, "font": "Arial", "size": 20, "media": []any{}},
+			{"name": "Dict", "ord": 2, "sticky": false, "rtl": false, "font": "Arial", "size": 14, "media": []any{}},
 		},
 		"css":           `.card{font-family:Arial;font-size:20px;text-align:left;color:#222;background:#fff;line-height:1.5;}`,
 		"req":           [][]any{{"Word-Definition", "any", []any{0}}},


### PR DESCRIPTION
## 问题
#774 的 anki 导出能生成合法 SQLite,但 **Anki 导入失败**(用 Anki 官方 Python 库 `AnkiPackageImporter` 验证发现):
- `col.ver=18` → Anki 跳过 schema 升级、直接查 `notetypes` 表 → `no such table: notetypes`
- `col.tags=""` → Anki 后端开库时把 tags 当 JSON 解析 → `EOF while parsing`

## 修复
- `col.ver` 18 → **11**(与 genanki 一致):Anki 开库时把 `col.models` JSON 升级成 `notetypes` 表,导入成功。
- `col.tags` `""` → **`{}`**。
- 字段补 `media:[]` 对齐 genanki。

## 验证(gold-standard)
新增门控回归测试 `TestAnkiPackageCompat`:用 **Anki 官方 `AnkiPackageImporter`**(用户导入 `.apkg` 的同一代码路径)导入生成的包并断言。设 `ANKI_VALIDATE_PYTHON=<装有 anki 的 python>` 才跑,默认 skip。

```
2 notes / 2 cards
decks: Default, Medict, Medict::Animals, Medict::Fruit
Definition: <style>…</style><p>a round fruit</p><img src="medict-<sha1>.png">   ← 图片正确抽成媒体
```

常驻 e2e 测试(`TestBuild_endToEnd`)加 `ver==11` / `tags=="{}"` 断言,防止两个 bug 回归。

## 复现方式
\`\`\`bash
python3 -m venv /tmp/anki-venv && /tmp/anki-venv/bin/pip install anki
ANKI_VALIDATE_PYTHON=/tmp/anki-venv/bin/python go test ./pkg/service/ankiexport/ -run TestAnkiPackageCompat -v
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)