### PR TITLE
feat(search): 多词典同时查询(类 GoldenDict)

### DIFF
--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -39,31 +39,35 @@ export interface HistoryEntry {
   record_block_data_decompress_size: number;
   keyword_data_start_offset: number;
   keyword_data_end_offset: number;
+  // 多词典查询历史条目:multi=true 时用 keyword + multiDicts 重放,offsets 字段忽略。
+  multi?: boolean;
+  multiDicts?: any[];
+}
+
+// MultiResult 是多词典堆叠里的一节:某词典对该词首个匹配的释义 URL(无匹配则 empty)。
+export interface MultiResult {
+  dictId: string;
+  dictName: string;
+  url: string;
+  empty: boolean;
+}
+
+// buildEntryURL 把一个词条匹配(entry,含 keyword 与各 offset)拼成 Gin 的释义查询 URL。
+// 抽出来供单词典(locateWord)与多词典(searchWordMulti)共用,dictId 显式传入。
+function buildEntryURL(baseurl: string, dictId: string, entry: any, entryId: number): string {
+  return `${baseurl}/__tcidem_query?dict_id=${dictId}` +
+    `&keyword=${entry.keyword}&record_start_offset=${entry.record_start_offset}` +
+    `&entry_id=${entryId}` +
+    `&record_end_offset=${entry.record_end_offset}` +
+    `&record_block_data_start_offset=${entry.record_block_data_start_offset}` +
+    `&record_block_data_compress_size=${entry.record_block_data_compress_size}` +
+    `&record_block_data_decompress_size=${entry.record_block_data_decompress_size}` +
+    `&keyword_data_start_offset=${entry.keyword_data_start_offset}` +
+    `&keyword_data_end_offset=${entry.keyword_data_end_offset}`;
 }
 
 function constructQueryURL(entry: HistoryEntry) {
-  let {
-    baseurl,
-    dict_id,
-    keyword,
-    record_start_offset,
-    record_end_offset,
-    entry_id,
-    record_block_data_start_offset,
-    record_block_data_compress_size,
-    record_block_data_decompress_size,
-    keyword_data_start_offset,
-    keyword_data_end_offset
-} = entry;
-  return `${baseurl}/__tcidem_query?dict_id=${dict_id}`+
-    `&keyword=${keyword}&record_start_offset=${record_start_offset}`+
-    `&entry_id=${entry_id}`+
-    `&record_end_offset=${record_end_offset}`+
-    `&record_block_data_start_offset=${record_block_data_start_offset}`+
-    `&record_block_data_compress_size=${record_block_data_compress_size}`+
-    `&record_block_data_decompress_size=${record_block_data_decompress_size}`+
-    `&keyword_data_start_offset=${keyword_data_start_offset}`+
-    `&keyword_data_end_offset=${keyword_data_end_offset}`;
+  return buildEntryURL(entry.baseurl, entry.dict_id, entry, entry.entry_id);
 }
 
 const DefaultContentTemplpate = `
@@ -121,6 +125,11 @@ export const useDictQueryStore = defineStore('dictQuery', {
     inputSearchWord: '',
 
     historyStack: new HistoryStack(),
+
+    // 多词典查询(类 GoldenDict):开关、激活词典集、堆叠结果。
+    multiMode: false,
+    multiSelectedDicts: [] as any[],
+    multiResults: [] as MultiResult[],
   }),
   actions: {
     initDicts() {
@@ -147,6 +156,11 @@ export const useDictQueryStore = defineStore('dictQuery', {
     },
     // 搜索单词
     searchWord(word: string) {
+      // 多词典模式:分发到 searchWordMulti(对激活集每个词典各查一次)。
+      if (this.multiMode) {
+        this.searchWordMulti(word);
+        return;
+      }
       if (this.selectDict.id === '') {
         return;
       }
@@ -216,6 +230,119 @@ export const useDictQueryStore = defineStore('dictQuery', {
       } else {
         this.updateSetCurrentDictAsContent();
       }
+    },
+    // ===================== 多词典查询(类 GoldenDict)=====================
+    // 开/关多词典模式。开启时若激活集为空,用当前 selectDict 播种,并对当前词重跑;
+    // 关闭时清空多结果并切回单词典视图。
+    setMultiMode(on: boolean) {
+      this.multiMode = on;
+      if (on) {
+        if (this.multiSelectedDicts.length === 0 && this.selectDict && this.selectDict.id !== '') {
+          this.multiSelectedDicts = [this.selectDict];
+        }
+        if (this.inputSearchWord && this.inputSearchWord.trim() !== '') {
+          this.searchWordMulti(this.inputSearchWord);
+        }
+      } else {
+        this.multiResults = [];
+        if (this.selectDict && this.selectDict.id !== '' && this.inputSearchWord && this.inputSearchWord.trim() !== '') {
+          this.searchWord(this.inputSearchWord);
+        }
+      }
+    },
+    // 在激活集里增/减一个词典,并对当前词重跑。
+    toggleMultiDict(dictItem: any) {
+      const i = this.multiSelectedDicts.findIndex((d) => d.id === dictItem.id);
+      if (i >= 0) {
+        this.multiSelectedDicts.splice(i, 1);
+      } else {
+        this.multiSelectedDicts.push(dictItem);
+      }
+      if (this.inputSearchWord && this.inputSearchWord.trim() !== '' && this.multiSelectedDicts.length > 0) {
+        this.searchWordMulti(this.inputSearchWord);
+      } else {
+        this.multiResults = [];
+      }
+    },
+    // 多词典搜索:对激活集每个词典并行 SearchWord,各取首个匹配拼成释义 URL;无匹配则 empty。
+    searchWordMulti(word: string) {
+      if (this.multiSelectedDicts.length === 0) {
+        this.multiResults = [];
+        return;
+      }
+      if (!word || word.trim() === '') {
+        return;
+      }
+      const baseurl = this.dictApiBaseURL;
+      const reqId = ++searchWordRequestId;
+      const dicts = [...this.multiSelectedDicts];
+      Promise.all(
+        dicts.map((d) =>
+          SearchWord(d.id, word)
+            .then((res: any) => ({ dict: d, res: res as any[] }))
+            .catch(() => ({ dict: d, res: [] as any[] }))
+        )
+      ).then((settled) => {
+        if (reqId !== searchWordRequestId) {
+          console.info('[store-action]{searchWordMulti} stale response, ignoring', word);
+          return;
+        }
+        const results: MultiResult[] = settled.map(({ dict, res }) => {
+          const list = Array.isArray(res) ? res : [];
+          const name = dict.name || (dict.description && dict.description.title) || dict.id;
+          if (list.length > 0) {
+            return { dictId: dict.id, dictName: name, url: buildEntryURL(baseurl, dict.id, list[0], 0), empty: false };
+          }
+          return { dictId: dict.id, dictName: name, url: '', empty: true };
+        });
+        this.multiResults = results;
+        // 主词典(激活集首项)的完整匹配列表供 sidebar 浏览。
+        const primary = dicts[0];
+        this.queryPendingList = settled.find((s) => s.dict.id === primary.id)?.res || [];
+        this.pushHistoryMulti(word, dicts);
+      }).catch((err) => {
+        if (reqId !== searchWordRequestId) return;
+        console.info('[store-action]{searchWordMulti} failed', err);
+        this.multiResults = [];
+      });
+    },
+    // 多模式:用主词典匹配列表的第 entryIdx 条更新堆叠中主词典那节的释义 URL。
+    locateInMultiPrimary(entryIdx: number) {
+      if (entryIdx < 0 || entryIdx >= this.queryPendingList.length) return;
+      const primary = this.multiSelectedDicts[0];
+      if (!primary) return;
+      const entry = this.queryPendingList[entryIdx];
+      const i = this.multiResults.findIndex((r) => r.dictId === primary.id);
+      if (i >= 0) {
+        this.multiResults[i] = {
+          ...this.multiResults[i],
+          url: buildEntryURL(this.dictApiBaseURL, primary.id, entry, entryIdx),
+          empty: false,
+        };
+      }
+    },
+    // 压一条多词典历史(keyword + 当时的激活集),供后退/前进重放。
+    pushHistoryMulti(keyword: string, dicts: any[]) {
+      if (!keyword || dicts.length === 0) return;
+      if (!this.historyStack.isEmpty() && this.historyStack.peek().keyword === keyword && this.historyStack.peek().multi) {
+        return;
+      }
+      this.historyStack.push({
+        baseurl: this.dictApiBaseURL,
+        dict_id: dicts[0].id,
+        dict: dicts[0],
+        keyword,
+        record_start_offset: 0,
+        record_end_offset: 0,
+        entry_id: 0,
+        record_block_data_start_offset: 0,
+        record_block_data_compress_size: 0,
+        record_block_data_decompress_size: 0,
+        keyword_data_start_offset: 0,
+        keyword_data_end_offset: 0,
+        multi: true,
+        multiDicts: dicts,
+      });
     },
     updateSetCurrentDictAsContent() {
         if (! this.selectDict || this.selectDict.id === '') {
@@ -374,6 +501,13 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
       this.updateInputSearchWord(locateQuerier.keyword)
 
+      // 多词典历史条目:还原激活集并重跑多词典搜索,不走单词典 locate 分支。
+      if (locateQuerier.multi && locateQuerier.multiDicts) {
+        this.multiSelectedDicts = locateQuerier.multiDicts;
+        this.searchWordMulti(locateQuerier.keyword);
+        return;
+      }
+
       if (this.selectDict.id != locateQuerier.dict_id) {
         this.selectDict = locateQuerier.dict;
       }
@@ -394,6 +528,13 @@ export const useDictQueryStore = defineStore('dictQuery', {
       }
 
       this.updateInputSearchWord(locateQuerier.keyword)
+
+      // 多词典历史条目:还原激活集并重跑多词典搜索,不走单词典 locate 分支。
+      if (locateQuerier.multi && locateQuerier.multiDicts) {
+        this.multiSelectedDicts = locateQuerier.multiDicts;
+        this.searchWordMulti(locateQuerier.keyword);
+        return;
+      }
 
       if (this.selectDict.id != locateQuerier.dict_id) {
         this.selectDict = locateQuerier.dict;

--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -63,6 +63,11 @@
       width: 100%;
       height: 100%;
     }
+    // 多词典模式:各词典释义节纵向堆叠,整体滚动
+    .multi-stack {
+      height: 100%;
+      overflow-y: auto;
+    }
   }
 }
 </style>
@@ -93,7 +98,18 @@
      </div>
     </div>
     <div id="app-content-main-iframe-wrapper" ref="wrapperRef">
+      <div v-if="showMulti" class="multi-stack">
+        <MainDictSection
+          v-for="(r, i) in dictQueryStore.multiResults"
+          :ref="el => { if (el) sectionRefs[i] = el as any; }"
+          :key="r.dictId"
+          :name="r.dictName"
+          :url="r.url"
+          :empty="r.empty"
+        />
+      </div>
       <iframe
+        v-else
         ref="iframeRef"
         class="app-content-main-iframe"
         :src="iframeSrc"
@@ -113,6 +129,7 @@ import { NIcon } from 'naive-ui';
 import { useMessage } from 'naive-ui';
 
 import MainDictsToolbar from "./MainDictsToolbar.vue";
+import MainDictSection from "./MainDictSection.vue";
 
 const dictQueryStore = useDictQueryStore();
 const message = useMessage();
@@ -127,6 +144,23 @@ const INNER_FRAME_MSG_DBLCLICK_LOOKUP = '__Medict_INNER_FRAME_MSG_EVTP_DBLCLICK_
 // 声明式 iframe：通过 Vue 响应式驱动 src，避免命令式 createElement / 手动设 .src
 const iframeRef = ref<HTMLIFrameElement | null>(null);
 const wrapperRef = ref<HTMLDivElement | null>(null);
+
+// 多词典模式：堆叠里各词典节的组件实例（暴露 iframeRef），用于广播缩放/刷新消息。
+const sectionRefs = ref<any[]>([]);
+const showMulti = computed(
+  () => dictQueryStore.multiMode && dictQueryStore.multiResults.length > 0
+);
+// 把消息广播给当前生效的 iframe：多模式发给所有 section，单模式发给唯一 iframe。
+function broadcast(evtype: string) {
+  const payload = { evtype, ts: new Date().getTime() };
+  if (showMulti.value) {
+    for (const s of sectionRefs.value) {
+      s?.iframeRef?.contentWindow?.postMessage(payload, '*');
+    }
+  } else {
+    iframeRef.value?.contentWindow?.postMessage(payload, '*');
+  }
+}
 
 // iframe 的 src：优先使用 mainContentURL（释义查询 URL），否则用 mainContent 构造 data URL。
 // 由 Vue 响应式驱动，store 中 mainContent / mainContentURL 变化时自动更新。
@@ -187,25 +221,16 @@ function todo() {
 
 // 缩小
 function zoomOut() {
-  iframeRef.value?.contentWindow?.postMessage(
-    { evtype: TOP_WIN_MSG_ZOOM_OUT, ts: new Date().getTime() },
-    '*'
-  );
+  broadcast(TOP_WIN_MSG_ZOOM_OUT);
 }
 
 function refresh() {
-  iframeRef.value?.contentWindow?.postMessage(
-    { evtype: TOP_WIN_MSG_REFRESH, ts: new Date().getTime() },
-    '*'
-  );
+  broadcast(TOP_WIN_MSG_REFRESH);
 }
 
 // 放大
 function zoomIn() {
-  iframeRef.value?.contentWindow?.postMessage(
-    { evtype: TOP_WIN_MSG_ZOOM_IN, ts: new Date().getTime() },
-    '*'
-  );
+  broadcast(TOP_WIN_MSG_ZOOM_IN);
 }
 
 // Ctrl/Cmd + =/- 与 Ctrl/Cmd + 滚轮缩放词典 iframe（#260）

--- a/frontend/src/view/main/MainDictSection.vue
+++ b/frontend/src/view/main/MainDictSection.vue
@@ -1,0 +1,113 @@
+<!--
+ Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!-- 多词典堆叠里的一节:词典名标题 + 单个释义 iframe。供 MainContentFrame 在多词典模式下 v-for。 -->
+<style lang="scss" scoped>
+.dict-section {
+  margin: 0 0 10px 0;
+  border: 1px solid #e3e3e3;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+
+  .dict-section-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 26px;
+    padding: 0 10px;
+    background: #f6f8fa;
+    border-bottom: 1px solid #e3e3e3;
+    font-size: 12px;
+    color: #555;
+    user-select: none;
+
+    .dict-section-name {
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .dict-section-tag {
+      color: #aaa;
+      font-size: 11px;
+    }
+  }
+  .dict-section-body {
+    height: 320px; // 每节固定高度,iframe 内部自滚动;整体堆叠由外层滚动
+    background: #fff;
+    position: relative;
+
+    .dict-section-iframe {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+    .dict-section-empty-body {
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #bbb;
+      font-size: 13px;
+    }
+  }
+}
+</style>
+
+<template>
+  <div class="dict-section">
+    <div class="dict-section-head">
+      <span class="dict-section-name">{{ name }}</span>
+      <span v-if="empty" class="dict-section-tag">无此词</span>
+    </div>
+    <div class="dict-section-body">
+      <div v-if="empty" class="dict-section-empty-body">该词典无此词</div>
+      <iframe
+        v-else
+        ref="iframeRef"
+        class="dict-section-iframe"
+        :src="url"
+        frameborder="0"
+        style="border: 0;"
+        @load="onLoad"
+      ></iframe>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+// 与 MainContentFrame 的 setup 消息约定一致(内嵌脚本据此挂载 entry:// 跳转/双击选词)。
+const SETUP_MSG = '__Medict_TOP_WIN_MSG__EVTY_SETUP__';
+
+const props = defineProps<{
+  name: string;
+  url: string;
+  empty: boolean;
+}>();
+
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+
+function onLoad() {
+  iframeRef.value?.contentWindow?.postMessage(SETUP_MSG, '*');
+}
+
+// 暴露给父组件,用于多词典模式下广播缩放/刷新消息。
+defineExpose({ iframeRef });
+</script>

--- a/frontend/src/view/main/MainRightToolbar.vue
+++ b/frontend/src/view/main/MainRightToolbar.vue
@@ -27,6 +27,7 @@
 
   .dictionary-item {
     display: block;
+    position: relative;
     width: 32px;
     height: 32px;
     text-align: center;
@@ -55,11 +56,53 @@
     box-shadow: rgba(0, 0, 0, 0.1) 0px 20px 25px -5px,
       rgba(0, 0, 0, 0.04) 0px 10px 10px -5px;
   }
+  // 多词典模式开关
+  .multi-toggle {
+    width: 32px;
+    height: 24px;
+    margin: 4px auto 8px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    background: #fff;
+    color: #666;
+    font-size: 12px;
+    cursor: pointer;
+    user-select: none;
+    &:hover {
+      background-color: #f1f1f1;
+    }
+  }
+  .multi-toggle-active {
+    background: #11a8ff;
+    color: #fff;
+    border-color: #11a8ff;
+  }
+  // 多模式下激活词典的角标
+  .dict-check {
+    position: absolute;
+    top: -3px;
+    right: -3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #11a8ff;
+    color: #fff;
+    font-size: 10px;
+    line-height: 14px;
+    text-align: center;
+    box-shadow: 0 0 0 1px #fff;
+  }
 }
 </style>
 <template>
   <AppRightToolbar>
     <div class="dictionaries">
+      <button
+        class="multi-toggle"
+        :class="{ 'multi-toggle-active': dictQueryStore.multiMode }"
+        title="多词典查询(开启后点词典图标多选)"
+        @click="dictQueryStore.setMultiMode(!dictQueryStore.multiMode)"
+      >多</button>
       <n-popover
         v-for="item in state.dictList"
         :overlap="false"
@@ -69,15 +112,11 @@
         <template #trigger>
           <span
             class="dictionary-item"
-            :class="
-              item.id == dictQueryStore.selectDict.id
-                ? 'dictionary-item-active'
-                : ''
-            "
+            :class="isActive(item) ? 'dictionary-item-active' : ''"
             :key="item.id"
             @click="chooseDict(item)"
             :style="getBackground(item)"
-          ></span>
+          ><span v-if="dictQueryStore.multiMode && isInMultiSet(item.id)" class="dict-check">✓</span></span>
         </template>
         <div class="large-text">
           <div>
@@ -112,7 +151,23 @@ const state = reactive({
 });
 
 function chooseDict(item) {
-  dictQueryStore.updateSelectDict(item);
+  // 多词典模式:点图标增/减激活集;否则单词典切换。
+  if (dictQueryStore.multiMode) {
+    dictQueryStore.toggleMultiDict(item);
+  } else {
+    dictQueryStore.updateSelectDict(item);
+  }
+}
+
+// 选中态:多模式下=在激活集里;单模式下=当前 selectDict。
+function isActive(item) {
+  if (dictQueryStore.multiMode) {
+    return dictQueryStore.multiSelectedDicts.some((d) => d.id === item.id);
+  }
+  return item.id == dictQueryStore.selectDict.id;
+}
+function isInMultiSet(id) {
+  return dictQueryStore.multiSelectedDicts.some((d) => d.id === id);
 }
 
 function getBackground(item) {

--- a/frontend/src/view/main/MainSidebar.vue
+++ b/frontend/src/view/main/MainSidebar.vue
@@ -73,9 +73,18 @@ import { ref, onMounted, onUnmounted } from 'vue';
 const dictQueryStore = useDictQueryStore();
 const selected_id = ref('0');
 
+// 按 entry 定位:多词典模式更新主词典那节,单词典模式走 locateWord。
+function locateEntry(entry_id) {
+  if (dictQueryStore.multiMode) {
+    dictQueryStore.locateInMultiPrimary(entry_id);
+  } else {
+    dictQueryStore.locateWord(entry_id);
+  }
+}
+
 function selectItem(entry_id) {
   selected_id.value = entry_id;
-  dictQueryStore.locateWord(entry_id);
+  locateEntry(entry_id);
 }
 
 // 焦点守卫：当用户正在输入框 / 文本域 / contenteditable 中输入时，不劫持方向键
@@ -105,14 +114,14 @@ function onKeyDown(e) {
     } else {
       selected_id.value = parseInt(selected_id.value) - 1;
     }
-    dictQueryStore.locateWord(selected_id.value);
+    locateEntry(selected_id.value);
   } else if (e.key == 'ArrowDown') {
     if (selected_id.value == len - 1) {
       selected_id.value = '0';
     } else {
       selected_id.value = parseInt(selected_id.value) + 1;
     }
-    dictQueryStore.locateWord(selected_id.value);
+    locateEntry(selected_id.value);
   }
 }
 


### PR DESCRIPTION
## 概述
实现 roadmap「多词典同时查询」:一次输入,同时查多个词典,释义**纵向堆叠**(类 GoldenDict)。**纯前端实现,零后端/IPC 改动**——`SearchWord(dictId, word)` 本就按任意词典查,释义由 Gin `/__tcidem_query?dict_id=…` 按任意 dict_id 提供,前端对各选中词典各查一次、各取首个匹配、各建 URL、内容区堆叠多 iframe。

## 用法
右侧词典栏顶部新增「**多**」开关:关=现在的单词典单击选择;开=点词典图标在「激活集」里多选(选中加 ✓),输入词 → 各词典释义纵向堆叠,无此词的词典显示占位。

## 改动
- **store/dict**:加 `multiMode`/`multiSelectedDicts`/`multiResults`;`constructQueryURL` 重构为 `buildEntryURL(baseurl,dictId,entry,entryId)`(dictId 显式传);`searchWord` 按模式分发到 `searchWordMulti`(并行 `SearchWord`、last-write-wins 防乱序);`setMultiMode`/`toggleMultiDict`/`locateInMultiPrimary`;`HistoryEntry` 加 `multi`/`multiDicts`,后退/前进支持多模式重放。
- **MainRightToolbar**:「多」开关;`chooseDict` 按模式分支;多模式选中态 ✓ 角标。
- **MainContentFrame**:多模式渲染 `MainDictSection` 堆叠;缩放/刷新广播给所有节;`entry://` 跳转/双击选词(已调 `searchWord`)两种模式自动适配。
- **MainDictSection**(新):词典名标题 + 单 iframe + 空结果占位。
- **MainSidebar**:多模式下点击/方向键走 `locateInMultiPrimary`(更新堆叠中主词典那节)。

## v1 边界(留待后续)
- 堆叠只展示各词典**首个匹配**;非主词典切换其它条目 = v2。
- 激活集**不持久化**(纯内存,重启重置)。需要的话可存进 `medict.toml`(viper),但会从纯前端变为碰后端配置。
- 服务端批量 `SearchWordMulti`(减少 N 次 IPC)= 后续优化。

## 验证
- `cd frontend && bun run build` ✅(类型/模板编译通过)
- `go build ./...` ✅(无 Go 改动)
- ⚠️ `wails dev` 桌面端手动回归需你来跑:① 关「多」→ 单词典查词/sidebar/entry跳转/后退前进 全不变;② 开「多」选 2–3 词典 → 堆叠释义;③ 堆叠内 entry:// 跳转;④ 缩放/刷新对所有节;⑤ 后退/前进多模式历史;⑥ 切回单词典。

🤖 Generated with [Claude Code](https://claude.com/claude-code)