### PR TITLE
feat(config): 设置回写基础设施(偏好持久化)

### DIFF
--- a/app.go
+++ b/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/op/go-logging"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
+	"github.com/terasum/medict/internal/config"
 	"github.com/terasum/medict/internal/entry"
 	"github.com/terasum/medict/internal/utils"
 	"github.com/terasum/medict/pkg/backserver"
@@ -44,6 +45,7 @@ type App struct {
 	bs           *backserver.BackServer
 	dictSvc      *service.DictService
 	bookmarks    *service.BookmarkStore
+	conf         *config.Config // app config (medict.toml);用于偏好回写
 	// initErr 捕获 appInit 同步阶段的错误，由 errorChanListen 在 Wails
 	// startup() 生命周期里确定性地产出，避免向无缓冲 channel 塞值带来的时序赌博。
 	initErr error
@@ -66,6 +68,7 @@ func (b *App) appInit() error {
 	if err != nil {
 		return err
 	}
+	b.conf = conf
 
 	dictsSvc, err := service.NewDictService(conf)
 	if err != nil {
@@ -142,6 +145,33 @@ func (b *App) SearchWord(dictId, word string) *model.Resp {
 
 func (b *App) BuildIndexByDictId(dictid string) *model.Resp {
 	return b.bs.Controller.BuildIndexByDictId(dictid)
+}
+
+// GetPreferences returns all persisted settings (medict.toml + runtime overrides)
+// as a flat map, for the frontend to read back. b.conf may be nil if appInit
+// failed — return an empty map in that case.
+//
+// Note: viper normalizes keys to lowercase, so returned keys are lowercase
+// regardless of the casing used when saving.
+func (b *App) GetPreferences() *model.Resp {
+	if b.conf == nil {
+		return model.BuildSuccess(map[string]any{})
+	}
+	return model.BuildSuccess(b.conf.Preferences())
+}
+
+// SavePreferences merges the given key/value pairs into medict.toml and writes
+// it back to disk; existing keys are preserved. Generic write-back path for user
+// preferences (multi-dict active set, theme, font size, …). Keys are
+// case-insensitive (viper lowercases them).
+func (b *App) SavePreferences(prefs map[string]any) *model.Resp {
+	if b.conf == nil {
+		return model.BuildError(errors.New("config not initialized"), model.InnerSysErrCode)
+	}
+	if err := b.conf.WritePreferences(prefs); err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	return model.BuildSuccess(nil)
 }
 
 // Bookmark / notebook IPC (#643)

--- a/frontend/src/apis/config.ts
+++ b/frontend/src/apis/config.ts
@@ -16,3 +16,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// 用户偏好(medict.toml)的读写包装。设置回写基础设施:任何「记住用户偏好」类
+// 需求(多词典激活集、主题、字号等)都通过这两个函数落盘,无需后端逐项加字段。
+//
+// 注意:viper 会把所有 key 小写化,所以 getPreferences 返回的 key 是小写的;
+// 保存时 key 大小写不敏感,建议统一用小写(如 multidictids)避免混淆。
+import * as App from '../../wailsjs/go/main/App';
+
+export type Preferences = Record<string, any>;
+
+// getPreferences 读取全部已持久化设置(medict.toml + 运行时覆盖)。
+export const getPreferences = async (): Promise<Preferences> => {
+    const resp = await App.GetPreferences();
+    return (resp.data as Preferences) || {};
+};
+
+// savePreferences 把给定 key/value 合并写入 medict.toml(保留既有 key)。
+// 失败(code != 200)抛错,由调用方 try/catch + message 提示。
+export const savePreferences = async (prefs: Preferences): Promise<void> => {
+    const resp = await App.SavePreferences(prefs);
+    if (resp.code !== 200) {
+        throw new Error(resp.err || '保存设置失败');
+    }
+};

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -22,6 +22,8 @@ export function GetBookmarks():Promise<model.Resp>;
 
 export function GetNotebooks():Promise<model.Resp>;
 
+export function GetPreferences():Promise<model.Resp>;
+
 export function InitDicts():Promise<model.Resp>;
 
 export function OpenFinder(arg1:string):Promise<void>;
@@ -31,6 +33,8 @@ export function RemoveBookmark(arg1:string,arg2:string,arg3:string):Promise<mode
 export function RenameNotebook(arg1:string,arg2:string):Promise<model.Resp>;
 
 export function ResourceServerAddr():Promise<string>;
+
+export function SavePreferences(arg1:{[key: string]: any}):Promise<model.Resp>;
 
 export function SearchWord(arg1:string,arg2:string):Promise<model.Resp>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -42,6 +42,10 @@ export function GetNotebooks() {
   return window['go']['main']['App']['GetNotebooks']();
 }
 
+export function GetPreferences() {
+  return window['go']['main']['App']['GetPreferences']();
+}
+
 export function InitDicts() {
   return window['go']['main']['App']['InitDicts']();
 }
@@ -60,6 +64,10 @@ export function RenameNotebook(arg1, arg2) {
 
 export function ResourceServerAddr() {
   return window['go']['main']['App']['ResourceServerAddr']();
+}
+
+export function SavePreferences(arg1) {
+  return window['go']['main']['App']['SavePreferences'](arg1);
 }
 
 export function SearchWord(arg1, arg2) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,23 @@ func (c *Config) Write() error {
 	return c.ViperInstance.WriteConfig()
 }
 
+// WritePreferences merges prefs into the config (viper.Set each key) and writes
+// the whole file back to disk; existing keys are preserved. This is the generic
+// write-back path for user preferences (multi-dict active set, theme, font size,
+// …): callers pass whatever keys they want to persist, no new IPC per setting.
+func (c *Config) WritePreferences(prefs map[string]any) error {
+	for k, v := range prefs {
+		c.ViperInstance.Set(k, v)
+	}
+	return c.ViperInstance.WriteConfig()
+}
+
+// Preferences returns all currently-held settings (file + any runtime Set
+// overrides) as a map, for the frontend to read back.
+func (c *Config) Preferences() map[string]any {
+	return c.ViperInstance.AllSettings()
+}
+
 func (c *Config) EnsureDictsDir() (string, error) {
 	dirPath := c.BaseDictDir
 	defer func() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -25,4 +27,47 @@ func TestReadConfig(t *testing.T) {
 	cfg, err := ReadConfig("./testdata/test.toml")
 	assert.Nil(t, err)
 	assert.Equal(t, cfg.BaseDictDir, "testdir")
+}
+
+// toStrSlice normalizes a viper slice ([]interface{} or []string) to []string
+// so the test doesn't depend on the codec's concrete type.
+func toStrSlice(v any) []string {
+	switch s := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(s))
+		for _, x := range s {
+			out = append(out, x.(string))
+		}
+		return out
+	case []string:
+		return s
+	}
+	return nil
+}
+
+// TestWritePreferences_RoundTrip writes a base toml, adds preferences via
+// WritePreferences, re-reads the same file and asserts the new keys landed AND
+// the pre-existing key (BaseDictDir) was preserved.
+func TestWritePreferences_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "medict.toml")
+	assert.Nil(t, os.WriteFile(path, []byte("BaseDictDir = \"/tmp/dicts\"\n"), 0o644))
+
+	cfg, err := ReadConfig(path)
+	assert.Nil(t, err)
+	assert.Nil(t, cfg.WritePreferences(map[string]any{
+		"MultiDictIds": []string{"a", "b"},
+		"FontSize":     18,
+	}))
+
+	// re-read the same file from disk
+	cfg2, err := ReadConfig(path)
+	assert.Nil(t, err)
+	prefs := cfg2.Preferences()
+
+	// viper normalizes all keys to lowercase (case-insensitive), so AllSettings
+	// returns lowercased keys regardless of the casing used at Set time.
+	assert.Equal(t, "/tmp/dicts", prefs["basedictdir"], "BaseDictDir must be preserved")
+	assert.Equal(t, []string{"a", "b"}, toStrSlice(prefs["multidictids"]), "MultiDictIds must round-trip")
+	assert.Contains(t, prefs, "fontsize")
 }


### PR DESCRIPTION
## 背景
`medict.toml` 此前**首次生成后只读**:`Config.Write()` 是死代码(无调用方)、无「保存设置」IPC,所以设置页改了也存不进。本 PR 补上**回写管道**,让任何「记住用户偏好」类需求有地方落盘。

## 改动
- **`internal/config/config.go`**:
  - `WritePreferences(prefs map[string]any) error` —— 对每个 key `viper.Set` 后 `WriteConfig()` 回写,既有 key 保留。
  - `Preferences() map[string]any` —— `AllSettings()` 供前端读回。
  - ⚠️ viper 把所有 key **小写化**(大小写不敏感),返回的 key 是小写的。
- **`app.go`**:App 持有 `conf`;新增 `GetPreferences()` / `SavePreferences(map[string]any)` IPC(nil 守卫 + `BuildSuccess/Error`)。
- **前端 `apis/config.ts`**:`getPreferences()` / `savePreferences(prefs)` 包装;wailsjs 绑定重生成。

## 验证
- `go build ./...` ✅
- `go test ./internal/config/` ✅(`TestWritePreferences_RoundTrip`:写入后重读,断言新 key 落盘 + 既有 `BaseDictDir` 保留)
- `bun run build` ✅

## 用法 / 后续
这是**纯基础设施**,无 UI 消费方。后续偏好(如 #776 多词典激活集、主题、字号)直接:
```ts
await savePreferences({ multidictids: [...] });   // 存
const prefs = await getPreferences();              // 读(注意 key 小写)
```
无需后端逐项加字段。

🤖 Generated with [Claude Code](https://claude.com/claude-code)