### PR TITLE
feat(multi-dict): 持久化激活集(接设置回写)

### DIFF
--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -20,6 +20,7 @@ import { defineStore } from 'pinia';
 
 import { InitDicts, GetAllDicts, SearchWord } from '@/apis/dicts-api';
 import { StaticDictServerURL } from '@/apis/apis';
+import { getPreferences, savePreferences } from '@/apis/config';
 
 /**
  * 历史栈条目类型。统一字段命名为 `keyword`，避免历史上 `keyword` / `key_word`
@@ -249,6 +250,7 @@ export const useDictQueryStore = defineStore('dictQuery', {
           this.searchWord(this.inputSearchWord);
         }
       }
+      this._persistMulti();
     },
     // 在激活集里增/减一个词典,并对当前词重跑。
     toggleMultiDict(dictItem: any) {
@@ -262,6 +264,29 @@ export const useDictQueryStore = defineStore('dictQuery', {
         this.searchWordMulti(this.inputSearchWord);
       } else {
         this.multiResults = [];
+      }
+      this._persistMulti();
+    },
+    // 把当前多词典开关 + 激活集持久化到 medict.toml(fire-and-forget,失败仅告警)。
+    _persistMulti() {
+      savePreferences({
+        multimode: this.multiMode,
+        multidictids: this.multiSelectedDicts.map((d) => d.id),
+      }).catch((e: any) => console.warn('[multi-dict] persist failed', e));
+    },
+    // 启动时按已保存的偏好恢复多词典开关与激活集(用全量词典列表把 id 还原成对象)。
+    async restoreMultiSelection(allDicts: any[]) {
+      try {
+        const prefs = await getPreferences();
+        const ids = Array.isArray(prefs.multidictids) ? prefs.multidictids.map(String) : [];
+        const idset = new Set(ids);
+        this.multiSelectedDicts = allDicts.filter((d) => idset.has(String(d.id)));
+        // 仅在曾经开过多词典、且激活集非空时恢复开关,避免首次用户被强制进入多模式
+        if (prefs.multimode === true && this.multiSelectedDicts.length > 0) {
+          this.multiMode = true;
+        }
+      } catch (e) {
+        console.warn('[multi-dict] restore selection failed', e);
       }
     },
     // 多词典搜索:对激活集每个词典并行 SearchWord,各取首个匹配拼成释义 URL;无匹配则 empty。

--- a/frontend/src/view/main/MainRightToolbar.vue
+++ b/frontend/src/view/main/MainRightToolbar.vue
@@ -219,6 +219,8 @@ function loadDictionaries() {
       state.dictList.push(res[i]);
       promiseArray.push(buildIndexPromise(i, res[i].id, res[i].name))
     }
+    // 词典列表就绪后,按已保存偏好恢复多词典开关与激活集
+    dictQueryStore.restoreMultiSelection(state.dictList);
     sequenceHandle(promiseArray);
   });
 }


### PR DESCRIPTION
把多词典开关 + 激活集存进 `medict.toml`,重启后恢复。基于已合并的多词典(#776)+ 设置回写(#777)。

## 改动(纯 wiring,~27 行)
- **store/dict**:`setMultiMode`/`toggleMultiDict` 末尾调 `_persistMulti()`(`savePreferences({multimode, multidictids})`,fire-and-forget,失败仅告警);新增 `restoreMultiSelection(allDicts)` 按 id 还原激活集(仅在曾开过且非空时恢复开关,避免首次用户被强制进入多模式)。
- **MainRightToolbar**:词典列表加载后调 `restoreMultiSelection(state.dictList)`。

> viper 小写化 key,故 toml 里是 `multimode` / `multidictids`(全小写)。

## 验证
- `bun run build` ✅
- 运行时(`wails dev`):开多词典→选 2–3 词典→关 App→重开 → 激活集与开关应恢复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)