### PR TITLE
fix(mdict): 词典标题在 BuildIndex 前回退到 mdx header(#782)

### DIFF
--- a/pkg/service/mdict/mdict_holder.go
+++ b/pkg/service/mdict/mdict_holder.go
@@ -279,22 +279,23 @@ func (mh *mdictHolder) ensureBkTree() error {
 	return nil
 }
 
+// Title returns the dictionary title. It prefers the leveldb meta (written
+// during BuildIndex) but falls back to the mdx header — which is parsed at load
+// (readDictHeader) — so the real title is available BEFORE indexing. Without
+// this fallback the dict list shows the filename, because GetMeta("Title") is
+// empty until BuildIndex runs (#782).
 func (mh *mdictHolder) Title() string {
-	value, err := mh.idxer.GetMeta("Title")
-	if err == nil {
-		return value
+	if v, err := mh.idxer.GetMeta("Title"); err == nil && v != "" {
+		return v
 	}
-	return ""
-
+	return mh.rawdict.Title()
 }
 
 func (mh *mdictHolder) Description() string {
-	value, err := mh.idxer.GetMeta("Description")
-	if err == nil {
-		return value
+	if v, err := mh.idxer.GetMeta("Description"); err == nil && v != "" {
+		return v
 	}
-	return ""
-
+	return mh.rawdict.Description()
 }
 
 func (mh *mdictHolder) CreationDate() string {


### PR DESCRIPTION
## 问题(#782)
词典列表/工具栏的显示名多用**文件名**,而非 mdx 里的真实标题。

## 根因
`mdictHolder.Title()/Description()` 只读 leveldb meta,而 meta 在 **BuildIndex 期间**才写入。词典**加载时(BuildIndex 之前)** `GetMeta("Title")` 为空 → `dictItem.Description.Title` 为空 → 显示回退到 `name`(`rawdict.Name()` = 文件名去扩展名)。

## 修复
meta 为空时回退到 `rawdict.Title()/Description()`(header 在 `readDictHeader` 加载时已解析),真实标题首次加载即可显示。

```go
func (mh *mdictHolder) Title() string {
    if v, err := mh.idxer.GetMeta("Title"); err == nil && v != "" { return v }
    return mh.rawdict.Title()
}
```

## 验证
- `go build ./...` ✅
- `go test ./pkg/service/mdict/...` ✅
- (运行时:首次加载词典,标题应直接显示 mdx title 而非文件名;留给桌面端 `wails dev` 确认。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)