### PR TITLE
feat(export): 导出当前词条为自包含 HTML(#784)

### DIFF
--- a/app.go
+++ b/app.go
@@ -303,6 +303,41 @@ func (b *App) ExportAnki(notebookId string) *model.Resp {
 	return model.BuildSuccess(path)
 }
 
+// ExportCurrentEntry renders the current word's definition as a self-contained
+// HTML (all resources inlined as data: URLs) and writes it to a user-chosen
+// file — for debugging complex entries (#784). Reuses RenderSnapshot (the same
+// Search→Locate→@@LINK→WrapContent→InlineResources path used by bookmark
+// snapshots). "" html means no match.
+func (b *App) ExportCurrentEntry(dictId, word string) *model.Resp {
+	if dictId == "" || word == "" {
+		return model.BuildError(errors.New("dictId 和 word 不能为空"), model.BadParamErrCode)
+	}
+	html, err := b.bs.Controller.RenderSnapshot(dictId, word)
+	if err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	if html == "" {
+		return model.BuildError(errors.New("未找到该词条"), model.BadParamErrCode)
+	}
+	path, err := runtime.SaveFileDialog(b.ctx, runtime.SaveDialogOptions{
+		Title:           "导出词条 HTML",
+		DefaultFilename: word + ".html",
+		Filters: []runtime.FileFilter{
+			{DisplayName: "HTML (*.html)", Pattern: "*.html"},
+		},
+	})
+	if err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	if path == "" {
+		return model.BuildSuccess(nil) // user cancelled the dialog
+	}
+	if err := os.WriteFile(path, []byte(html), 0o644); err != nil {
+		return model.BuildError(err, model.InnerSysErrCode)
+	}
+	return model.BuildSuccess(path)
+}
+
 func (b *App) ResourceServerAddr() string {
 	return b.bs.StaticServerBaseUrl()
 }

--- a/frontend/src/apis/dicts-api.ts
+++ b/frontend/src/apis/dicts-api.ts
@@ -42,3 +42,14 @@ export const SearchWord = async function (dictid: string, word: string): Promise
     const resp = await App.SearchWord(dictid, word);
     return resp.data as model.Resp;
 }
+
+// exportCurrentEntry 把当前词条渲染为自包含 HTML(资源内联)并保存到用户选择的
+// 路径,便于调试复杂词条(#784)。返回保存路径;用户取消对话框返回 '';
+// 后端错误(code != 200)抛错,由调用方 message 提示。
+export const exportCurrentEntry = async function (dictid: string, word: string): Promise<string> {
+    const resp = await App.ExportCurrentEntry(dictid, word);
+    if (resp.code !== 200) {
+        throw new Error(resp.err || '导出失败');
+    }
+    return (resp.data as string) || '';
+}

--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -79,7 +79,7 @@
          <MainDictsToolbar/>
       </div>
       <div class="toolbar-boxes">
-      <span class="app-content-main-toolbar-box" @click="todo"
+      <span class="app-content-main-toolbar-box" title="导出当前词条 HTML(调试)" @click="onExportEntry"
         ><NIcon><Bug16Regular /></NIcon
       ></span>
       <span class="app-content-main-toolbar-box" @click="todo"
@@ -127,6 +127,7 @@ import { useDictQueryStore } from '@/store/dict';
 import { ZoomIn16Regular, ZoomOut16Regular,ArrowClockwise20Filled, Bug16Regular, DocumentCss20Regular } from '@vicons/fluent';
 import { NIcon } from 'naive-ui';
 import { useMessage } from 'naive-ui';
+import { exportCurrentEntry } from '@/apis/dicts-api';
 
 import MainDictsToolbar from "./MainDictsToolbar.vue";
 import MainDictSection from "./MainDictSection.vue";
@@ -212,6 +213,25 @@ function onInnerFrameMessage(e: MessageEvent) {
       }
       break;
     }
+  }
+}
+
+// 导出当前词条为自包含 HTML(资源内联)到本地文件,用于调试复杂词条(#784)。
+// 用当前选中词典 + 输入词;多词典模式下导出主词典的释义。
+async function onExportEntry() {
+  const dict = dictQueryStore.selectDict;
+  const word = dictQueryStore.inputSearchWord;
+  if (!dict?.id || !word?.trim()) {
+    message.warning('请先查一个词');
+    return;
+  }
+  try {
+    const path = await exportCurrentEntry(dict.id, word.trim());
+    if (path) {
+      message.success(`已导出：${path}`);
+    } // 用户取消保存对话框时不提示
+  } catch (e) {
+    message.error((e as Error)?.message || '导出失败');
   }
 }
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -14,6 +14,8 @@ export function DeleteNotebook(arg1:string):Promise<model.Resp>;
 
 export function ExportAnki(arg1:string):Promise<model.Resp>;
 
+export function ExportCurrentEntry(arg1:string,arg2:string):Promise<model.Resp>;
+
 export function GetAllDicts():Promise<model.Resp>;
 
 export function GetBookmarkSnapshot(arg1:string,arg2:string,arg3:string):Promise<model.Resp>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -26,6 +26,10 @@ export function ExportAnki(arg1) {
   return window['go']['main']['App']['ExportAnki'](arg1);
 }
 
+export function ExportCurrentEntry(arg1, arg2) {
+  return window['go']['main']['App']['ExportCurrentEntry'](arg1, arg2);
+}
+
 export function GetAllDicts() {
   return window['go']['main']['App']['GetAllDicts']();
 }


### PR DESCRIPTION
## 概述(#784)
把**当前词条**渲染为**资源内联的自包含 HTML**并保存到本地文件,用于调试结构复杂的词条(参考 #259 okayer 建议)。

## 实现
复用已有的 `RenderSnapshot`(Search→Locate→@@LINK→WrapContent→InlineResources,生词本快照同款管线):
- **app.go** `ExportCurrentEntry(dictId, word)`:RenderSnapshot → `SaveFileDialog` → `os.WriteFile`(取消对话框/未找到词条/参数空均安全处理)。
- **前端** `dicts-api.exportCurrentEntry`;把 `MainContentFrame` 工具栏的 debug(bug)按钮从「功能开发中」接到 `onExportEntry`(用 `selectDict.id` + `inputSearchWord`;多词典模式下导出主词典释义)。
- wailsjs 绑定重生成。

## 验证
- `go build ./...` ✅
- `bun run build` ✅
- (运行时 `wails dev`:查一个词 → 点 debug 按钮 → 选路径保存 → 文件为内联图片/字体的单文件 HTML。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)