### PR TITLE
feat(dict): 词典显示名优先取 Title(#782)

### DIFF
--- a/pkg/service/dict_item.go
+++ b/pkg/service/dict_item.go
@@ -24,6 +24,7 @@ import (
 	"github.com/terasum/medict/pkg/service/mdict"
 	"github.com/terasum/medict/pkg/service/stardict"
 	"os"
+	"strings"
 )
 
 func NewByDirItem(dirItem *model.DirItem) (*model.DictionaryItem, error) {
@@ -78,6 +79,14 @@ func NewByDirItem(dirItem *model.DirItem) (*model.DictionaryItem, error) {
 	}
 
 	dictItem.Description = dictItem.Dict.Description()
+
+	// 优先用词典自带的 Title(mdx header 的 Title / stardict bookname)作显示名,
+	// 空则保持上面的文件名/目录名回退(dict.Name())。此前显示名一律取文件名。(#782)
+	if dictItem.Description != nil {
+		if t := strings.TrimSpace(dictItem.Description.Title); t != "" {
+			dictItem.Name = t
+		}
+	}
 
 	return dictItem, nil
 

--- a/pkg/service/dict_item_name_test.go
+++ b/pkg/service/dict_item_name_test.go
@@ -1,0 +1,68 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/terasum/medict/pkg/service/support"
+)
+
+// TestNewByDirItem_NameFromTitle verifies #782: the dict display Name should
+// come from the embedded Title (mdx header Title / stardict bookname) when
+// present, falling back to the file/dir name otherwise. Uses the in-repo
+// testdata dicts (relative paths) so it actually runs on any host.
+func TestNewByDirItem_NameFromTitle(t *testing.T) {
+	items, err := support.WalkDir("support/testdata/dicts")
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if len(items) == 0 {
+		t.Skip("no testdata dicts present under support/testdata/dicts")
+	}
+	// 部分 testdata mdx 是占位 stub(打开会 EOF),逐个跳过、只对成功打开的断言。
+	opened := 0
+	for _, di := range items {
+		item, err := NewByDirItem(di)
+		if err != nil {
+			t.Logf("%s: NewByDirItem error, skipping: %v", di.CurrentDir, err)
+			continue
+		}
+		opened++
+		title := ""
+		if item.Description != nil {
+			title = strings.TrimSpace(item.Description.Title)
+		}
+		switch {
+		case title != "":
+			// 有 Title → 显示名应等于 Title
+			if item.Name != title {
+				t.Errorf("%s: Name=%q, want Title %q", di.CurrentDir, item.Name, title)
+			}
+		default:
+			// 无 Title → 回退到文件名/目录名(必须非空)
+			if item.Name == "" {
+				t.Errorf("%s: Name empty and no Title fallback", di.CurrentDir)
+			}
+		}
+		t.Logf("%s: Name=%q Title=%q", di.CurrentDir, item.Name, title)
+	}
+	if opened == 0 {
+		t.Skip("no testdata dict could be opened (testdata mdx are stubs)")
+	}
+}


### PR DESCRIPTION
实现 #782:添加词典后,显示名**优先取词典自带的 Title**(mdx header 的 Title 字段 / stardict 的 bookname),空则回退到文件名/目录名。此前一律用文件名。

## 改动
- `pkg/service/dict_item.go`:`NewByDirItem` 在取完 `Description` 后,若 `Description.Title` 非空则用它作 `Name`,否则保持文件名回退。
  - mdict:`Description.Title` 来自 `mdx.Title()`(header XML 的 Title,早已解析,见 `internal/libs/go-mdict`)。
  - stardict:来自 `GetBookName()`。
- mdx 无独立「别名」字段 → 别名自动填充不适用(无数据源),仅做名称。

## 验证
- `go build ./...` ✅
- `go test ./pkg/service/...` ✅(新增 `TestNewByDirItem_NameFromTitle`:用仓库内 testdata,逐个跳过 stub mdx,对成功打开的词典断言 Name==Title 或非空回退)

🤖 Generated with [Claude Code](https://claude.com/claude-code)