### PR TITLE
feat(lookup): 悬停弹窗查词(#780)

### DIFF
--- a/frontend/src/components/dict/HoverDictPopup.vue
+++ b/frontend/src/components/dict/HoverDictPopup.vue
@@ -1,0 +1,155 @@
+<!--
+ Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!-- 悬停弹窗(#780):在光标附近浮出该词的完整释义(GoldenDict 式)。
+     内容 = SearchWord 首匹配 → buildEntryURL → iframe(复用内容管线)。
+     经 <Teleport to="body"> + fixed 高 z-index,盖在主 iframe 之上。
+     弹窗内的 entry:// 跳转会以 postMessage 冒泡到父窗(走 ENTRY_JUMP 通路)。 -->
+<style lang="scss" scoped>
+.hover-popup {
+  position: fixed;
+  z-index: 1001;
+  width: 380px;
+  max-height: 320px;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+
+  .hover-popup-head {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 26px;
+    padding: 0 10px;
+    background: #f6f8fa;
+    border-bottom: 1px solid #e3e3e3;
+    font-size: 12px;
+    .hover-popup-word { font-weight: 600; color: #24292f; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .hover-popup-status { color: #999; }
+  }
+  .hover-popup-body {
+    flex: 1 1 auto;
+    height: 280px;
+    background: #fff;
+    .hover-popup-iframe { width: 100%; height: 100%; display: block; }
+    .hover-popup-placeholder { height: 100%; display: flex; align-items: center; justify-content: center; color: #bbb; font-size: 13px; }
+  }
+}
+</style>
+
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="hover-popup" :style="posStyle" @mouseleave="onLeave">
+      <div class="hover-popup-head">
+        <span class="hover-popup-word">{{ word }}</span>
+        <span v-if="loading" class="hover-popup-status">查询中…</span>
+        <span v-else-if="empty" class="hover-popup-status">无此词</span>
+      </div>
+      <div class="hover-popup-body">
+        <div v-if="empty || loading" class="hover-popup-placeholder">
+          {{ empty ? '该词典无此词' : '查询中…' }}
+        </div>
+        <iframe
+          v-else-if="url"
+          ref="iframeRef"
+          class="hover-popup-iframe"
+          :src="url"
+          frameborder="0"
+          style="border: 0;"
+          @load="onIframeLoad"
+        ></iframe>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue';
+import { SearchWord } from '@/apis/dicts-api';
+import { buildEntryURL, useDictQueryStore } from '@/store/dict';
+
+const props = defineProps<{
+  visible: boolean;
+  word: string;
+  dictId: string;
+  x: number;
+  y: number;
+}>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const dictQueryStore = useDictQueryStore();
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+const url = ref('');
+const loading = ref(false);
+const empty = ref(false);
+
+const SETUP_MSG = '__Medict_TOP_WIN_MSG__EVTY_SETUP__';
+
+// 贴边翻转:预估尺寸,超出视口则翻到光标另一侧。
+const posStyle = computed(() => {
+  const W = 380, H = 320, margin = 12;
+  let left = props.x + margin;
+  let top = props.y + margin;
+  if (left + W > window.innerWidth) left = Math.max(8, props.x - W - margin);
+  if (top + H > window.innerHeight) top = Math.max(8, props.y - H - margin);
+  return { left: left + 'px', top: top + 'px' };
+});
+
+// 词/词典变化时取释义 URL。visible 关闭时清空。
+watch(
+  () => [props.visible, props.word, props.dictId] as const,
+  async ([vis, word, dictId]) => {
+    if (!vis || !word || !dictId) {
+      url.value = ''; empty.value = false; loading.value = false;
+      return;
+    }
+    loading.value = true; empty.value = false; url.value = '';
+    try {
+      const res: any = await SearchWord(dictId, String(word));
+      const list = Array.isArray(res) ? res : [];
+      if (list.length === 0) {
+        empty.value = true;
+      } else {
+        url.value = buildEntryURL(dictQueryStore.dictApiBaseURL, dictId, list[0], 0);
+      }
+    } catch (e) {
+      empty.value = true;
+    }
+    loading.value = false;
+  },
+  { immediate: true }
+);
+
+function onIframeLoad() {
+  // 弹窗内禁用 hover 取词(避免弹窗叠弹窗 + 省掉无谓的 mousemove 处理)。
+  iframeRef.value?.contentWindow?.postMessage(
+    { evtype: SETUP_MSG, hoverEnabled: false } as any,
+    '*'
+  );
+}
+
+function onLeave() {
+  emit('close');
+}
+
+defineExpose({ iframeRef });
+</script>

--- a/frontend/src/store/dict/index.ts
+++ b/frontend/src/store/dict/index.ts
@@ -54,8 +54,8 @@ export interface MultiResult {
 }
 
 // buildEntryURL 把一个词条匹配(entry,含 keyword 与各 offset)拼成 Gin 的释义查询 URL。
-// 抽出来供单词典(locateWord)与多词典(searchWordMulti)共用,dictId 显式传入。
-function buildEntryURL(baseurl: string, dictId: string, entry: any, entryId: number): string {
+// 抽出来供单词典(locateWord)、多词典(searchWordMulti)与悬停弹窗共用,dictId 显式传入。
+export function buildEntryURL(baseurl: string, dictId: string, entry: any, entryId: number): string {
   return `${baseurl}/__tcidem_query?dict_id=${dictId}` +
     `&keyword=${entry.keyword}&record_start_offset=${entry.record_start_offset}` +
     `&entry_id=${entryId}` +

--- a/frontend/src/view/main/MainContentFrame.vue
+++ b/frontend/src/view/main/MainContentFrame.vue
@@ -118,6 +118,15 @@
         @load="onIframeLoad"
       ></iframe>
     </div>
+    <HoverDictPopup
+      ref="popupRef"
+      :visible="popupVisible"
+      :word="popupWord"
+      :dict-id="popupDictId"
+      :x="popupX"
+      :y="popupY"
+      @close="popupVisible = false"
+    />
   </div>
 </template>
 
@@ -128,9 +137,11 @@ import { ZoomIn16Regular, ZoomOut16Regular,ArrowClockwise20Filled, Bug16Regular,
 import { NIcon } from 'naive-ui';
 import { useMessage } from 'naive-ui';
 import { exportCurrentEntry } from '@/apis/dicts-api';
+import { getPreferences } from '@/apis/config';
 
 import MainDictsToolbar from "./MainDictsToolbar.vue";
 import MainDictSection from "./MainDictSection.vue";
+import HoverDictPopup from "@/components/dict/HoverDictPopup.vue";
 
 const dictQueryStore = useDictQueryStore();
 const message = useMessage();
@@ -141,6 +152,8 @@ const TOP_WIN_MSG_REFRESH = '__Medict_TOP_WIN_MSG_EVTP_REFRESH';
 const TOP_WIN_MSG_SETUP =  '__Medict_TOP_WIN_MSG__EVTY_SETUP__';
 const INNER_FRAME_MSG_ENTRY_JUMP = '__Medict_INNER_FRAME_MSG_EVTP_ENTRY_JUMP';
 const INNER_FRAME_MSG_DBLCLICK_LOOKUP = '__Medict_INNER_FRAME_MSG_EVTP_DBLCLICK_LOOKUP';
+const INNER_FRAME_MSG_HOVER_LOOKUP = '__Medict_INNER_FRAME_MSG_EVTP_HOVER_LOOKUP';
+const INNER_FRAME_MSG_HOVER_LEAVE = '__Medict_INNER_FRAME_MSG_EVTP_HOVER_LEAVE';
 
 // 声明式 iframe：通过 Vue 响应式驱动 src，避免命令式 createElement / 手动设 .src
 const iframeRef = ref<HTMLIFrameElement | null>(null);
@@ -163,6 +176,38 @@ function broadcast(evtype: string) {
   }
 }
 
+// 悬停弹窗(#780):设置(从 preferences 读,默认开/400ms)+ 弹窗状态。
+const hoverEnabled = ref(true);
+const hoverDelayMs = ref(400);
+const popupVisible = ref(false);
+const popupWord = ref('');
+const popupDictId = ref('');
+const popupX = ref(0);
+const popupY = ref(0);
+const popupRef = ref<any>(null);
+
+// 弹窗用主/激活词典:多词典模式取激活集首项,否则当前选中词典。
+function activeDictId(): string {
+  if (dictQueryStore.multiMode && dictQueryStore.multiSelectedDicts.length > 0) {
+    return dictQueryStore.multiSelectedDicts[0]?.id || '';
+  }
+  return dictQueryStore.selectDict?.id || '';
+}
+// 找到消息来源 iframe(单 iframe 或多词典某节)的屏幕位置,用于坐标映射。
+function resolveSourceRect(e: MessageEvent): DOMRect | null {
+  const single = iframeRef.value;
+  if (single && e.source === single.contentWindow) {
+    return single.getBoundingClientRect();
+  }
+  for (const s of sectionRefs.value) {
+    const f = s?.iframeRef as HTMLIFrameElement | null;
+    if (f && e.source === f.contentWindow) {
+      return f.getBoundingClientRect();
+    }
+  }
+  return null;
+}
+
 // iframe 的 src：优先使用 mainContentURL（释义查询 URL），否则用 mainContent 构造 data URL。
 // 由 Vue 响应式驱动，store 中 mainContent / mainContentURL 变化时自动更新。
 const iframeSrc = computed(() => {
@@ -174,13 +219,16 @@ const iframeSrc = computed(() => {
   return 'data:text/html;charset=utf-8;base64,' + btoa(unescape(encodeURIComponent(decoded)));
 });
 
-// iframe 加载完成后发送 setup 消息（替代原来的 1s setTimeout）
+// iframe 加载完成后发送 setup 消息（替代原来的 1s setTimeout），并下发 hover 设置(#780)
 function onIframeLoad() {
   const win = iframeRef.value?.contentWindow;
   if (!win) {
     return;
   }
-  win.postMessage(TOP_WIN_MSG_SETUP, '*');
+  win.postMessage(
+    { evtype: TOP_WIN_MSG_SETUP, hoverEnabled: hoverEnabled.value, hoverDelayMs: hoverDelayMs.value } as any,
+    '*'
+  );
 }
 
 // 监听内嵌 iframe 的消息（entry:// 跳转等）。
@@ -190,6 +238,9 @@ function onInnerFrameMessage(e: MessageEvent) {
   if (!e || !e.data || !e.data.evtype) {
     return;
   }
+  // 弹窗自身 iframe 发来的消息:entry:///双击照常处理(并关弹窗),hover 一律忽略(防递归)
+  const popupIframe = popupRef.value?.iframeRef as HTMLIFrameElement | null;
+  const fromPopup = !!popupIframe && e.source === popupIframe.contentWindow;
 
   switch (e.data.evtype) {
     // entry:// 跳转
@@ -200,7 +251,7 @@ function onInnerFrameMessage(e: MessageEvent) {
       dictQueryStore.updateInputSearchWord(keyWord);
       dictQueryStore.searchWord(keyWord);
       dictQueryStore.pushHistoryByEntryIDx(0);
-
+      if (fromPopup) popupVisible.value = false;
       break;
     }
     // 双击选词查词（#258）
@@ -211,6 +262,29 @@ function onInnerFrameMessage(e: MessageEvent) {
         dictQueryStore.searchWord(keyWord);
         dictQueryStore.pushHistoryByEntryIDx(0);
       }
+      if (fromPopup) popupVisible.value = false;
+      break;
+    }
+    // 悬停取词(#780):坐标映射后弹窗
+    case INNER_FRAME_MSG_HOVER_LOOKUP: {
+      if (fromPopup || !hoverEnabled.value) break;
+      const word = String(e.data.word || '').trim();
+      const dictId = activeDictId();
+      if (!word || !dictId) break;
+      const r = resolveSourceRect(e);
+      const baseX = r ? r.left : 0;
+      const baseY = r ? r.top : 0;
+      popupWord.value = word;
+      popupDictId.value = dictId;
+      popupX.value = baseX + Number(e.data.clientX || 0);
+      popupY.value = baseY + Number(e.data.clientY || 0);
+      popupVisible.value = true;
+      break;
+    }
+    // 悬停离开(移出/滚动/ESC):关弹窗
+    case INNER_FRAME_MSG_HOVER_LEAVE: {
+      if (fromPopup) break;
+      popupVisible.value = false;
       break;
     }
   }
@@ -283,6 +357,12 @@ onMounted(() => {
   setTimeout(function () {
     dictQueryStore.setUpAPIBaseURL();
   }, 1000);
+  // 读取悬停弹窗偏好(#777):hoverpopup 默认 true,hoverdelayms 默认 400
+  getPreferences().then((p: any) => {
+    hoverEnabled.value = p?.hoverpopup !== false;
+    const d = Number(p?.hoverdelayms);
+    hoverDelayMs.value = d > 0 ? d : 400;
+  }).catch(() => { /* 用默认值 */ });
 });
 
 onUnmounted(() => {

--- a/internal/static/tmpl/dict_def_templ.go
+++ b/internal/static/tmpl/dict_def_templ.go
@@ -43,6 +43,9 @@ function __medict_play_sound(mp3url) {
 //**************************
 var __TOPFRAME_SECURE_ORIGIN__ = "*";
 var __MEDICT_DICT_ID__ = "%s";
+// hover 查词配置:由父窗经 SETUP 消息下发(#780)。默认开、400ms。
+var __medictHoverEnabled = true;
+var __medictHoverDelayMs = 400;
 function __medict_entry_jump(word, dict_id) {
 	console.log("[inner frame] jump entry => ", word, dict_id);
 	if (window.top){
@@ -76,6 +79,11 @@ function __medict_entry_jump(word, dict_id) {
 			console.log("refresh event", e);
 			window.location.reload();
 		}
+		// SETUP 携带 hover 设置(父侧经 #777 preferences 控制,免每请求注入模板)
+		if (e && e.data && e.data.evtype === "__Medict_TOP_WIN_MSG__EVTY_SETUP__"){
+			if (typeof e.data.hoverEnabled === "boolean") { __medictHoverEnabled = e.data.hoverEnabled; }
+			if (typeof e.data.hoverDelayMs === "number" && e.data.hoverDelayMs > 0) { __medictHoverDelayMs = e.data.hoverDelayMs; }
+		}
     })
 }())
 
@@ -103,6 +111,51 @@ function __medict_entry_jump(word, dict_id) {
 			window.top.postMessage({"evtype":"__Medict_INNER_FRAME_MSG_EVTP_DBLCLICK_LOOKUP", "word": sel}, __TOPFRAME_SECURE_ORIGIN__);
 		}
 	});
+	// ===== 悬停弹窗取词(#780)=====
+	// 取光标位置的「词」:caretRangeFromPoint 得文本节点 + offset;CJK(0x3400-0xFAFF)
+	// 按单字返回,拉丁/数字/连字符按词边界扩展。
+	function __medict_wordAtPoint(x, y) {
+		var rng = document.caretRangeFromPoint ? document.caretRangeFromPoint(x, y) : null;
+		if (!rng || !rng.startContainer) { return ""; }
+		var node = rng.startContainer;
+		if (node.nodeType !== 3 /* TEXT_NODE */) { return ""; }
+		var text = node.textContent || "";
+		var off = rng.startOffset;
+		if (off < 0 || off >= text.length) { return ""; }
+		var ch = text.charCodeAt(off);
+		if (ch >= 0x3400 && ch <= 0xFAFF) { return text.charAt(off); } // CJK 单字
+		var re = /[A-Za-z0-9'-]/;
+		if (!re.test(text.charAt(off))) { return ""; }
+		var s = off, end = off;
+		while (s > 0 && re.test(text.charAt(s - 1))) { s--; }
+		while (end < text.length - 1 && re.test(text.charAt(end + 1))) { end++; }
+		return text.slice(s, end + 1);
+	}
+	var __hoverTimer = null;
+	var __lastHoverWord = "";
+	function __medict_hoverLeave() {
+		if (__hoverTimer) { clearTimeout(__hoverTimer); __hoverTimer = null; }
+		if (__lastHoverWord !== "") {
+			__lastHoverWord = "";
+			window.top.postMessage({"evtype":"__Medict_INNER_FRAME_MSG_EVTP_HOVER_LEAVE"}, __TOPFRAME_SECURE_ORIGIN__);
+		}
+	}
+	document.addEventListener("mousemove", function(ev) {
+		if (!__medictHoverEnabled) { return; }
+		var x = ev.clientX, y = ev.clientY;
+		if (__hoverTimer) { clearTimeout(__hoverTimer); }
+		__hoverTimer = setTimeout(function() {
+			__hoverTimer = null;
+			var w = __medict_wordAtPoint(x, y);
+			if (w && w !== __lastHoverWord) {
+				__lastHoverWord = w;
+				window.top.postMessage({"evtype":"__Medict_INNER_FRAME_MSG_EVTP_HOVER_LOOKUP", "word": w, "clientX": x, "clientY": y}, __TOPFRAME_SECURE_ORIGIN__);
+			}
+		}, __medictHoverDelayMs);
+	});
+	document.addEventListener("mouseleave", __medict_hoverLeave);
+	window.addEventListener("scroll", __medict_hoverLeave, true);
+	window.addEventListener("keydown", function(ev){ if (ev.key === "Escape") __medict_hoverLeave(); });
 }());
 
 </script>


### PR DESCRIPTION
实现 #780(释义内查词,类 macOS Dictionary / GoldenDict),方案为「**双击 + 悬停弹窗**」:释义内悬停某词 ~0.4s → 光标附近浮窗显示该词**完整释义**;保留双击(#258)与 entry:// 跳转。纯前端 + 模板内联 JS,无后端逻辑改动。

## 改动
- **内嵌脚本 `dict_def_templ.go`**:SETUP 消息由父窗携带 `hoverEnabled`/`hoverDelayMs` 下发(设置存父侧,经 #777 preferences);mousemove 防抖 → `caretRangeFromPoint` 取光标位置词(拉丁按词边界 `[A-Za-z0-9'-]`、CJK 按单字)→ postMessage `HOVER_LOOKUP {word,clientX,clientY}`;mouseleave/scroll/Esc → `HOVER_LEAVE`。
- **新组件 `HoverDictPopup.vue`**:`<Teleport to="body">` + fixed 贴边翻转 + z-index 1001;`SearchWord` → 首匹配 → 复用 `buildEntryURL` → iframe 显完整释义;loading / 无匹配态;弹窗内 `SETUP hoverEnabled:false` 禁用 hover(防递归)。
- **`MainContentFrame.vue`**:`HOVER_LOOKUP` 坐标映射(来源 iframe `getBoundingClientRect()` + clientX/Y → 屏幕坐标,单/多模式都覆盖)→ 开弹窗;`HOVER_LEAVE` 关;**防递归**(忽略弹窗自身 iframe 的 hover);SETUP 下发偏好(`onMounted` 读 `getPreferences` 的 `hoverpopup`/`hoverdelayms`);弹窗内 entry:// 跳转后关弹窗。
- **store**:导出 `buildEntryURL` 供弹窗复用。

## 设置(#777)
`hoverpopup`(默认 true)、`hoverdelayms`(默认 400)。v1 默认开;设置页 UI 开关后补。

## v1 边界
- 弹窗用主/激活词典(`selectDict`;多模式取 `multiSelectedDicts[0]`)。弹窗内多词典堆叠 = v2。
- CJK 按单字取词(不接分词);拉丁按词边界。

## 验证
- `go build ./...` ✅ · `bun run build` ✅
- ⚠️ `wails dev` 桌面端手动回归:① 悬停 ~0.4s 出完整释义浮窗;② 移开/ESC 消隐;③ 双击仍跳全屏(#258 回归);④ entry:// 仍跳转;⑤ 弹窗内 entry:// 可点且不再叠弹窗;⑥ iframe 滚动时浮窗消隐;⑦ `hoverpopup=false` 不弹。

🤖 Generated with [Claude Code](https://claude.com/claude-code)