### PR TITLE
fix(filewalker): 递归扫描嵌套词典目录不再重复/误判(#257)

### DIFF
--- a/pkg/service/support/filewalker.go
+++ b/pkg/service/support/filewalker.go
@@ -96,40 +96,39 @@ func innerWalkLevel2(level1Path, level2Path string) (*model.DirItem, error) {
 		IsValid:         false,
 	}
 
-	err1 := filepath.Walk(level2Path, func(path string, info fs.FileInfo, err error) error {
-		if err != nil {
-			return fmt.Errorf("level2 inner walk dir failed, path %s, %s", path, err)
+	// 只看 DIRECT 子文件(不递归进子目录):一个目录直接含词典文件才算一个词典;
+	// 分类/分组目录(词典在更深层)由 WalkDir 在更深层各自评估,避免嵌套时重复发现
+	// 同一个词典、或把分类目录误当词典。(#257)
+	entries, err1 := os.ReadDir(level2Path)
+	if err1 != nil {
+		return item, err1
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
 		}
-
-		// skip directory
-		if info.IsDir() {
-			return nil
-		}
-
-		// verify multiple directory types, such as
-		// order0: medict.type file
-		// order1: medict type
-		// order2: stardict type
+		name := e.Name()
+		path := filepath.Join(level2Path, name)
 
 		// predefined file type
-		if info.Name() == "cover.jpg" {
+		if name == "cover.jpg" {
 			item.CoverImgPath = utils.FileAbs(path)
 			item.CoverImgType = model.ImgTypeJPG
-		} else if info.Name() == "cover.png" {
+		} else if name == "cover.png" {
 			item.CoverImgPath = utils.FileAbs(path)
 			item.CoverImgType = model.ImgTypePNG
-		} else if info.Name() == "mdict.toml" {
+		} else if name == "mdict.toml" {
 			item.DictType = model.DictTypeMdict
 			item.ConfigPath = utils.FileAbs(path)
-		} else if info.Name() == "stardict.toml" {
+		} else if name == "stardict.toml" {
 			item.DictType = model.DictTypeStarDict
 			item.ConfigPath = utils.FileAbs(path)
-		} else if info.Name() == "dict.license" {
+		} else if name == "dict.license" {
 			item.LicensePath = utils.FileAbs(path)
 		}
 
 		// if mdx
-		if filepath.Ext(info.Name()) == ".mdx" {
+		if filepath.Ext(name) == ".mdx" {
 			item.MdictMdxAbsPath, _ = filepath.Abs(path)
 			item.MdictMdxFileName = utils.FileNameWithoutExt(path)
 			baseDir := utils.FileBaseDir(path)
@@ -149,34 +148,32 @@ func innerWalkLevel2(level1Path, level2Path string) (*model.DirItem, error) {
 			}
 			item.DictType = model.DictTypeMdict
 			item.IsValid = true
-		} else if filepath.Ext(info.Name()) == ".mdd" {
+		} else if filepath.Ext(name) == ".mdd" {
 			// MDD append
 			mddAbs, _ := filepath.Abs(path)
 			item.MdictMddAbsPath = append(item.MdictMddAbsPath, mddAbs)
 		}
 
 		// if stardict
-		if filepath.Ext(info.Name()) == ".dz" {
+		if filepath.Ext(name) == ".dz" {
 			item.StarDictDzAbsPath, _ = filepath.Abs(path)
 			item.DictType = model.DictTypeStarDict
 			item.IsValid = true
-		} else if filepath.Ext(info.Name()) == ".dict" {
+		} else if filepath.Ext(name) == ".dict" {
 			item.StarDictAbsPath, _ = filepath.Abs(path)
 			item.DictType = model.DictTypeStarDict
 			item.IsValid = true
-		} else if filepath.Ext(info.Name()) == ".ifo" {
+		} else if filepath.Ext(name) == ".ifo" {
 			item.StarDictIfoAbsPath, _ = filepath.Abs(path)
-		} else if filepath.Ext(info.Name()) == ".idx" {
+		} else if filepath.Ext(name) == ".idx" {
 			item.StarDictIdxAbsPath, _ = filepath.Abs(path)
 		}
 
 		// ecdict:离线英汉 preset(目录里有 ecdict.db 即识别)
-		if info.Name() == "ecdict.db" {
+		if name == "ecdict.db" {
 			item.DictType = model.DictTypeECDICT
 			item.IsValid = true
 		}
-
-		return nil
-	})
-	return item, err1
+	}
+	return item, nil
 }

--- a/pkg/service/support/filewalker_nested_test.go
+++ b/pkg/service/support/filewalker_nested_test.go
@@ -1,0 +1,106 @@
+//
+// Copyright (C) 2023 Quan Chen <chenquan_act@163.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package support
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func touchFile(t *testing.T, root, rel string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestWalkDir_NestedNoDup: a category folder holding two dicts must find each
+// dict exactly once and must NOT register the category folder itself as a dict.
+// Regression for #257 (recursive auto-scan previously double-counted nested
+// dicts and mis-attributed them to the category dir).
+func TestWalkDir_NestedNoDup(t *testing.T) {
+	root := t.TempDir()
+	touchFile(t, root, "English/OALD9/oald9.mdx")
+	touchFile(t, root, "English/OALD9/oald9.mdd")
+	touchFile(t, root, "English/COBUILD/cobuild.mdx")
+	touchFile(t, root, "cc-cedict/cc-cedict.mdx")
+	touchFile(t, root, "stardict1/stardict.ifo")
+	touchFile(t, root, "stardict1/stardict.idx")
+	touchFile(t, root, "stardict1/stardict.dict.dz")
+
+	items, err := WalkDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(items))
+	for _, it := range items {
+		got = append(got, filepath.Base(it.CurrentDir))
+	}
+	sort.Strings(got)
+
+	want := []string{"COBUILD", "OALD9", "cc-cedict", "stardict1"}
+	if len(got) != len(want) {
+		t.Fatalf("found %d dicts %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("dict[%d] = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
+	}
+	count := func(name string) int {
+		c := 0
+		for _, n := range got {
+			if n == name {
+				c++
+			}
+		}
+		return c
+	}
+	if count("English") != 0 {
+		t.Errorf("category dir English must not be a dict: %v", got)
+	}
+	if count("OALD9") != 1 {
+		t.Errorf("OALD9 must appear once, got %d: %v", count("OALD9"), got)
+	}
+}
+
+// TestWalkDir_FlatInTemp: classic flat layout via temp dir (one dict dir → one dict).
+func TestWalkDir_FlatInTemp(t *testing.T) {
+	root := t.TempDir()
+	touchFile(t, root, "oale3/test.mdx")
+	touchFile(t, root, "oale3/test.mdd")
+	touchFile(t, root, "oale3/test.png") // cover candidate same basename as mdx
+	items, err := WalkDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || filepath.Base(items[0].CurrentDir) != "oale3" {
+		t.Fatalf("expected one dict oale3, got %+v", items)
+	}
+	if items[0].MdictMdxAbsPath == "" || len(items[0].MdictMddAbsPath) != 1 {
+		t.Errorf("mdx/mdd not captured: %+v", items[0])
+	}
+	if items[0].CoverImgType != "png" || items[0].CoverImgPath == "" {
+		t.Errorf("cover png (same basename as mdx) not captured: %+v", items[0])
+	}
+}


### PR DESCRIPTION
修 #257 的标题部分(指定目录 recursive 自动扫描)。

## 问题
`innerWalkLevel2` 用 `filepath.Walk`(递归),会把**子树任意深度**的词典文件算给当前目录。嵌套结构 `English/{OALD9,COBUILD}/oald9.mdx` 下:
- OALD9 **重复**发现(作为 `English` 和 `OALD9` 各一份);
- 分类目录 `English` 被**误判为词典**,且只抢到子树第一个 mdx。

实测:`English/OALD9/oald9.mdx + COBUILD + cc-cedict + stardict1` → 返回 5 个(含错误的 `English`)。

## 修复
`innerWalkLevel2` 改用 `os.ReadDir` **只看直接子文件**(不递归进子目录):
- 一个目录**直接含**词典文件(mdx/mdd 或 stardict ifo/idx/dz 或 ecdict.db)才算一个词典;
- 分类目录(词典在更深层)由 `WalkDir` 在更深层各自评估;
- → 每个词典叶子目录**恰好发现一次**,嵌套正常,扁平结构不变。

## 验证
- `go test ./pkg/service/support/` ✅
- 新增 `TestWalkDir_NestedNoDup`(分类目录不出现、OALD9 仅一次)、`TestWalkDir_FlatInTemp`;
- 现有 `TestWalkDir`(扁平 testdata,断言 3 个)**无回归**。
- `go test ./...` ✅

## 范围
#257 标题(recursive 自动扫描)修复。**Group 功能**(子目录作分组、跨组共享词典,见 issue 评论)是单独的较大 feature,不在本次范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)